### PR TITLE
Fix : github stars number is missing from home page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,15 +203,11 @@
                       >
                       <a
                         class="btn btn-outline-primary btn-home-gitstar fw-500"
+                        href="https://github.com/open-metadata/OpenMetadata/stargazers"
                       >
-                        <iframe
-                          src="https://ghbtns.com/github-btn.html?user=open-metadata&repo=OpenMetadata&type=star&count=true&size=large"
-                          frameborder="0"
-                          scrolling="0"
-                          width="140"
-                          height="30"
-                          title="GitHub"
-                        ></iframe>
+                      <img src="https://img.shields.io/github/stars/open-metadata?style=social" alt="github-stars" width="120"
+                      height="30"
+                      title="GitHub Stars">
                       </a>
                     </div>
                   </div>


### PR DESCRIPTION
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/59080942/172450557-90723023-c426-44d1-bcad-342c9c59205e.png">
