### PR TITLE
Add lazy loading for images

### DIFF
--- a/community.html
+++ b/community.html
@@ -80,9 +80,9 @@
             class="navbar navbar-marketing navbar-expand-lg bg-transparent navbar-light fixed-top"
           >
             <div class="container px-5">
-              <a class="navbar-brand text-primary" href="index.html"
-                ><img alt="omd-logo" src="images/omd-logo.svg"
-              /></a>
+              <a class="navbar-brand text-primary" href="index.html">
+                <img alt="omd-logo" src="images/omd-logo.svg" loading="lazy" />
+              </a>
               <button
                 class="navbar-toggler"
                 type="button"
@@ -157,6 +157,7 @@
                       class="img-fluid"
                       src="images/community.png"
                       alt="community"
+                      loading="lazy"
                     />
                   </div>
                   <div class="col-lg-6" data-aos="fade-up">
@@ -193,6 +194,7 @@
                           src="images/icon-slack.svg"
                           height="18"
                           alt="slack"
+                          loading="lazy"
                         />&nbsp; Join our Slack</a
                       >
                     </div>
@@ -240,6 +242,7 @@
                     src="images/meetups.png"
                     class="img-fluid"
                     alt="meetups"
+                    loading="lazy"
                   />
                 </div>
               </div>
@@ -419,7 +422,11 @@
             <div class="row gx-5">
               <div class="col-lg-3">
                 <div class="footer-brand">
-                  <img src="images/omd-logo-footer.svg" alt="omd-footer-logo" />
+                  <img
+                    src="images/omd-logo-footer.svg"
+                    alt="omd-footer-logo"
+                    loading="lazy"
+                  />
                 </div>
                 <div class="mb-3">
                   Open Standard for Metadata with a Centralized Metadata Store.
@@ -499,7 +506,12 @@
                 <div class="text-uppercase-expanded text-xs mb-2">
                   Developed By
                 </div>
-                <img src="images/netlify.png" width="120" alt="netlify" />
+                <img
+                  src="images/netlify.png"
+                  width="120"
+                  alt="netlify"
+                  loading="lazy"
+                />
               </div>
             </div>
             <hr class="my-5" />

--- a/index.html
+++ b/index.html
@@ -89,7 +89,10 @@
           >
             <div class="container px-5">
               <a class="navbar-brand text-primary" href="index.html"
-                ><img src="images/omd-logo.svg" alt="omd-logo-svg"
+                ><img
+                  src="images/omd-logo.svg"
+                  alt="omd-logo-svg"
+                  loading="lazy"
               /></a>
               <button
                 class="navbar-toggler"
@@ -199,15 +202,21 @@
                           src="images/icon-slack.svg"
                           height="18"
                           alt="slack-logo-svg"
+                          loading="lazy"
                         />&nbsp; Join our Slack</a
                       >
                       <a
                         class="btn btn-outline-primary btn-home-gitstar fw-500"
                         href="https://github.com/open-metadata/OpenMetadata/stargazers"
                       >
-                      <img src="https://img.shields.io/github/stars/open-metadata?style=social" alt="github-stars" width="120"
-                      height="30"
-                      title="GitHub Stars">
+                        <img
+                          src="https://img.shields.io/github/stars/open-metadata?style=social"
+                          alt="github-stars"
+                          width="120"
+                          height="30"
+                          title="GitHub Stars"
+                          loading="lazy"
+                        />
                       </a>
                     </div>
                   </div>
@@ -220,6 +229,7 @@
                       class="img-fluid"
                       src="images/home-section.png"
                       alt="home-section-img"
+                      loading="lazy"
                     />
                   </div>
                 </div>
@@ -339,6 +349,7 @@
                     height="80"
                     class="mb-4"
                     alt="git-svg"
+                    loading="lazy"
                   />
                   <h3>Let’s Build on GitHub</h3>
                   <p>
@@ -358,6 +369,7 @@
                     height="80"
                     class="mb-4"
                     alt="doc-svg"
+                    loading="lazy"
                   />
                   <h3>Refer Documentation</h3>
                   <p>
@@ -377,6 +389,7 @@
                     height="80"
                     class="mb-4"
                     alt="slack-icon-svg"
+                    loading="lazy"
                   />
                   <h3>Connect on Slack</h3>
                   <p>
@@ -396,6 +409,7 @@
                     height="80"
                     class="mb-4"
                     alt="join-us-svg"
+                    loading="lazy"
                   />
                   <h3>Join our Community</h3>
                   <p>
@@ -465,6 +479,7 @@
                       class="img-fluid shadow-lg rounded-3"
                       src="images/feature01.jpg"
                       alt="feature01"
+                      loading="lazy"
                     />
                   </div>
                 </div>
@@ -478,6 +493,7 @@
                       class="img-fluid shadow-lg rounded-3"
                       src="images/feature02.jpg"
                       alt="feature02"
+                      loading="lazy"
                     />
                   </div>
                 </div>
@@ -543,6 +559,7 @@
                       class="img-fluid shadow-lg rounded-3"
                       src="images/feature03.jpg"
                       alt="feature03"
+                      loading="lazy"
                     />
                   </div>
                 </div>
@@ -554,6 +571,7 @@
                       class="img-fluid shadow-lg rounded-3"
                       src="images/feature04.jpg"
                       alt="feature04"
+                      loading="lazy"
                     />
                   </div>
                 </div>
@@ -621,6 +639,7 @@
                       src="images/services/airflow.png"
                       class="media-img mb-2"
                       alt="service-airflow"
+                      loading="lazy"
                     />
                     <h5>Airflow</h5>
                   </a>
@@ -633,6 +652,7 @@
                     src="images/services/amundsen.png"
                     class="media-img mb-2"
                     alt="service-amundsen"
+                    loading="lazy"
                   />
                   <h5>Amundsen</h5>
                 </div>
@@ -648,6 +668,7 @@
                       src="images/services/athena.png"
                       class="media-img mb-2"
                       alt="service-athena"
+                      loading="lazy"
                     />
                     <h5>Athena</h5>
                   </a>
@@ -660,6 +681,7 @@
                     src="images/services/atlas.png"
                     class="media-img mb-2"
                     alt="service-atlas"
+                    loading="lazy"
                   />
                   <h5>Atlas</h5>
                 </div>
@@ -675,6 +697,7 @@
                       src="images/services/bigquery.png"
                       class="media-img mb-2"
                       alt="service-bigquery"
+                      loading="lazy"
                     />
                     <h5>BigQuery</h5>
                   </a>
@@ -687,6 +710,7 @@
                     src="images/services/dbt.png"
                     class="media-img mb-2"
                     alt="service-dbt"
+                    loading="lazy"
                   />
                   <h5>dbt</h5>
                 </div>
@@ -703,6 +727,7 @@
                       src="images/services/deltalake.png"
                       class="media-img mb-2"
                       alt="service-deltalake"
+                      loading="lazy"
                     />
                     <h5>Delta Lake</h5>
                   </a>
@@ -715,6 +740,7 @@
                     src="images/services/druid.png"
                     class="media-img mb-2"
                     alt="service-druid"
+                    loading="lazy"
                   />
                   <h5>Druid</h5>
                 </div>
@@ -730,6 +756,7 @@
                       src="images/services/elasticsearch.png"
                       class="media-img mb-2"
                       alt="service-elasticsearch"
+                      loading="lazy"
                     />
                     <h5>Elasticsearch</h5>
                   </a>
@@ -746,6 +773,7 @@
                       src="images/services/glue.png"
                       class="media-img mb-2"
                       alt="service-glue"
+                      loading="lazy"
                     />
                     <h5>Glue</h5>
                   </a>
@@ -762,6 +790,7 @@
                       src="images/services/hive.png"
                       class="media-img mb-2"
                       alt="service-hive"
+                      loading="lazy"
                     />
                     <h5>Hive</h5>
                   </a>
@@ -778,6 +807,7 @@
                       src="images/services/ibmdb2.png"
                       class="media-img mb-2"
                       alt="service-ibmdb2"
+                      loading="lazy"
                     />
                     <h5>IBM Db2</h5>
                   </a>
@@ -795,6 +825,7 @@
                       src="images/services/kafka.png"
                       class="media-img mb-2"
                       alt="service-kafka"
+                      loading="lazy"
                     />
                     <h5>Kafka</h5>
                   </a>
@@ -811,6 +842,7 @@
                       src="images/services/looker.png"
                       class="media-img mb-2"
                       alt="service-looker"
+                      loading="lazy"
                     />
                     <h5>Looker</h5>
                   </a>
@@ -827,6 +859,7 @@
                       src="images/services/mariadb.png"
                       class="media-img mb-2"
                       alt="service-mariadb"
+                      loading="lazy"
                     />
                     <h5>MariaDB</h5>
                   </a>
@@ -843,6 +876,7 @@
                       src="images/services/metabase.png"
                       class="media-img mb-2"
                       alt="service-metabase"
+                      loading="lazy"
                     />
                     <h5>Metabase</h5>
                   </a>
@@ -859,6 +893,7 @@
                       src="images/services/mssql.png"
                       class="media-img mb-2"
                       alt="service-mssql"
+                      loading="lazy"
                     />
                     <h5>MSSQL</h5>
                   </a>
@@ -875,6 +910,7 @@
                       src="images/services/mysql.png"
                       class="media-img mb-2"
                       alt="service-mysql"
+                      loading="lazy"
                     />
                     <h5>MySQL</h5>
                   </a>
@@ -892,6 +928,7 @@
                       src="images/services/oracle.png"
                       class="media-img mb-2"
                       alt="service-oracle"
+                      loading="lazy"
                     />
                     <h5>Oracle</h5>
                   </a>
@@ -908,6 +945,7 @@
                       src="images/services/postgres.png"
                       class="media-img mb-2"
                       alt="service-postgres"
+                      loading="lazy"
                     />
                     <h5>Postgres</h5>
                   </a>
@@ -920,6 +958,7 @@
                     src="images/services/perfect.png"
                     class="media-img mb-2"
                     alt="service-perfect"
+                    loading="lazy"
                   />
                   <h5>Prefect</h5>
                 </div>
@@ -935,6 +974,7 @@
                       src="images/services/presto.png"
                       class="media-img mb-2"
                       alt="service-presto"
+                      loading="lazy"
                     />
                     <h5>Presto</h5>
                   </a>
@@ -947,6 +987,7 @@
                     src="images/services/pulsar.png"
                     class="media-img mb-2"
                     alt="service-pulsar"
+                    loading="lazy"
                   />
                   <h5>Pulsar</h5>
                 </div>
@@ -962,6 +1003,7 @@
                       src="images/services/redash.png"
                       class="media-img mb-2"
                       alt="service-redash"
+                      loading="lazy"
                     />
                     <h5>Redash</h5>
                   </a>
@@ -979,6 +1021,7 @@
                       src="images/services/redshift.png"
                       class="media-img mb-2"
                       alt="service-redshift"
+                      loading="lazy"
                     />
                     <h5>Redshift</h5>
                   </a>
@@ -995,6 +1038,7 @@
                       src="images/services/salesforce.png"
                       class="media-img mb-2"
                       alt="service-salesforce"
+                      loading="lazy"
                     />
                     <h5>Salesforce</h5>
                   </a>
@@ -1011,6 +1055,7 @@
                       src="images/services/snowflake.png"
                       class="media-img mb-2"
                       alt="service-snowflake"
+                      loading="lazy"
                     />
                     <h5>Snowflake</h5>
                   </a>
@@ -1027,6 +1072,7 @@
                       src="images/services/superset.png"
                       class="media-img mb-2"
                       alt="service-superset"
+                      loading="lazy"
                     />
                     <h5>Superset</h5>
                   </a>
@@ -1043,6 +1089,7 @@
                       src="images/services/tableu.png"
                       class="media-img mb-2"
                       alt="service-tablue"
+                      loading="lazy"
                     />
                     <h5>Tableau</h5>
                   </a>
@@ -1059,6 +1106,7 @@
                       src="images/services/trino.png"
                       class="media-img mb-2"
                       alt="service-trino"
+                      loading="lazy"
                     />
                     <h5>Trino</h5>
                   </a>
@@ -1076,6 +1124,7 @@
                       src="images/services/vertica.png"
                       class="media-img mb-2"
                       alt="service-vertica"
+                      loading="lazy"
                     />
                     <h5>Vertica</h5>
                   </a>
@@ -1092,6 +1141,7 @@
                       src="images/services/mlflow.png"
                       class="media-img mb-2"
                       alt="service-mlflow"
+                      loading="lazy"
                     />
                     <h5>MLflow</h5>
                   </a>
@@ -1104,6 +1154,7 @@
                     src="images/services/sqlalchemy.png"
                     class="media-img mb-2"
                     alt="service-sqlalchemy"
+                    loading="lazy"
                   />
                   <h5>SQLAlchemy</h5>
                 </div>
@@ -1115,6 +1166,7 @@
                     src="images/services/ldap.png"
                     class="media-img mb-2"
                     alt="service-ldap"
+                    loading="lazy"
                   />
                   <h5>LDAP</h5>
                 </div>
@@ -1126,6 +1178,7 @@
                     src="images/services/clickhouse.png"
                     class="media-img mb-2"
                     alt="service-clickhouse"
+                    loading="lazy"
                   />
                   <h5>ClickHouse</h5>
                 </div>
@@ -1141,6 +1194,7 @@
                       src="images/services/databrick.png"
                       class="media-img mb-2"
                       alt="service-databrick"
+                      loading="lazy"
                     />
                     <h5>Databricks</h5>
                   </a>
@@ -1158,6 +1212,7 @@
                       src="images/services/singlestore.png"
                       class="media-img mb-2"
                       alt="service-singlestore"
+                      loading="lazy"
                     />
                     <h5>SingleStore</h5>
                   </a>
@@ -1174,6 +1229,7 @@
                       src="images/services/azuresql.png"
                       class="media-img mb-2"
                       alt="service-azuresql"
+                      loading="lazy"
                     />
                     <h5>Azure SQL</h5>
                   </a>
@@ -1186,6 +1242,7 @@
                     src="images/services/iceberg.png"
                     class="media-img mb-2"
                     alt="service-iceberg"
+                    loading="lazy"
                   />
                   <h5>Apache Iceberg</h5>
                 </div>
@@ -1197,6 +1254,7 @@
                     src="images/services/powerbi.png"
                     class="media-img mb-2"
                     alt="service-powerbi"
+                    loading="lazy"
                   />
                   <h5>Power BI</h5>
                 </div>
@@ -1212,6 +1270,7 @@
                       src="images/services/dynamodb.png"
                       class="media-img mb-2"
                       alt="service-dynamodb"
+                      loading="lazy"
                     />
                     <h5>DynamoDB</h5>
                   </a>
@@ -1225,6 +1284,7 @@
                       src="images/services/sqllite.png"
                       class="media-img mb-2"
                       alt="service-sqlite"
+                      loading="lazy"
                     />
                     <h5>SQL Lite</h5>
                   </a>
@@ -1297,6 +1357,7 @@
                       class="card-img-top"
                       src="./images/v0.9.0.jpg"
                       alt="v0.9.0"
+                      loading="lazy"
                     />
                     <div class="card-body">
                       <h4 class="card-title mb-2">
@@ -1343,6 +1404,7 @@
                       class="card-img-top"
                       src="images/blogml.jpg"
                       alt="blogml"
+                      loading="lazy"
                     />
                     <div class="card-body">
                       <h4 class="card-title mb-2">ML is not just about ML</h4>
@@ -1387,6 +1449,7 @@
                       class="card-img-top"
                       src="./images/RBAC.png"
                       alt="RBAC"
+                      loading="lazy"
                     />
                     <div class="card-body">
                       <h4 class="card-title mb-2">
@@ -1453,7 +1516,11 @@
             <div class="row gx-5">
               <div class="col-lg-3">
                 <div class="footer-brand">
-                  <img src="images/omd-logo-footer.svg" alt="omd-footer-logo" />
+                  <img
+                    src="images/omd-logo-footer.svg"
+                    alt="omd-footer-logo"
+                    loading="lazy"
+                  />
                 </div>
                 <div class="mb-3">
                   Open Standard for Metadata with a Centralized Metadata Store.
@@ -1533,7 +1600,12 @@
                 <div class="text-uppercase-expanded text-xs mb-2">
                   Deployed By
                 </div>
-                <img src="images/netlify.png" width="120" alt="netlify-png" />
+                <img
+                  src="images/netlify.png"
+                  width="120"
+                  alt="netlify-png"
+                  loading="lazy"
+                />
               </div>
             </div>
             <hr class="my-5" />


### PR DESCRIPTION
This PR will add support for the lazy loading images.

> Lazy Loading Images is a set of web and application development techniques that defer the loading of images on a page to a later point in time - when those images are actually needed, instead of loading them up front. These techniques help in improving performance, better utilisation of the device’s resources, and reducing associated costs.

Watch the video to see how images are getting loaded when actually needed.

https://user-images.githubusercontent.com/59080942/173236453-eae43524-6f85-45b9-853f-02e4910221c5.mov

