### PR TITLE
Change the connectors path from `openmetadata/connectors` to `connectors`

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,9 +73,9 @@
       function gtag() {
         dataLayer.push(arguments);
       }
-      gtag("js", new Date());
+      gtag('js', new Date());
 
-      gtag("config", "G-LBLK284YQW");
+      gtag('config', 'G-LBLK284YQW');
     </script>
   </head>
 
@@ -653,7 +653,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/metadata/amundsen"
+                    href="https://docs.open-metadata.org/connectors/metadata/amundsen"
                     target="_blank"
                   >
                     <img
@@ -711,7 +711,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/pipeline/airbyte"
+                    href="https://docs.open-metadata.org/connectors/pipeline/airbyte"
                     target="_blank"
                   >
                     <img
@@ -728,7 +728,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/database/datalake"
+                    href="https://docs.open-metadata.org/connectors/database/datalake"
                     target="_blank"
                   >
                     <img
@@ -791,7 +791,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/database/clickhouse"
+                    href="https://docs.open-metadata.org/connectors/database/clickhouse"
                     target="_blank"
                   >
                     <img
@@ -826,7 +826,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/pipeline/dagster"
+                    href="https://docs.open-metadata.org/connectors/pipeline/dagster"
                     target="_blank"
                   >
                     <img
@@ -860,7 +860,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/database/druid"
+                    href="https://docs.open-metadata.org/connectors/database/druid"
                     target="_blank"
                   >
                     <img
@@ -877,7 +877,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/database/databricks"
+                    href="https://docs.open-metadata.org/connectors/database/databricks"
                     target="_blank"
                   >
                     <img
@@ -911,7 +911,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/pipeline/fivetran"
+                    href="https://docs.open-metadata.org/connectors/pipeline/fivetran"
                     target="_blank"
                   >
                     <img
@@ -945,7 +945,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/database/datalake"
+                    href="https://docs.open-metadata.org/connectors/database/datalake"
                     target="_blank"
                   >
                     <img
@@ -1111,7 +1111,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/ml-model/mlflow"
+                    href="https://docs.open-metadata.org/connectors/ml-model/mlflow"
                     target="_blank"
                   >
                     <img
@@ -1128,7 +1128,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/dashboard/mode"
+                    href="https://docs.open-metadata.org/connectors/dashboard/mode"
                     target="_blank"
                   >
                     <img
@@ -1231,7 +1231,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/dashboard/powerbi"
+                    href="https://docs.open-metadata.org/connectors/dashboard/powerbi"
                     target="_blank"
                   >
                     <img
@@ -1265,7 +1265,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/messaging/redpanda"
+                    href="https://docs.open-metadata.org/connectors/messaging/redpanda"
                     target="_blank"
                   >
                     <img
@@ -1334,7 +1334,7 @@
                   data-aos="fade-up"
                 >
                   <a
-                    href="https://docs.open-metadata.org/openmetadata/connectors/dashboard/superset"
+                    href="https://docs.open-metadata.org/connectors/dashboard/superset"
                     target="_blank"
                   >
                     <img
@@ -1788,7 +1788,7 @@
     <script src="js/clipboard.js"></script>
     <script>
       AOS.init({
-        disable: "mobile",
+        disable: 'mobile',
         duration: 600,
         once: true,
       });


### PR DESCRIPTION
I worked on changing the connectors doc path from `openmetadata/connectors` to `connectors`.

**Example :** 

`https://docs.open-metadata.org/openmetadata/connectors/metadata/amundsen` --> `https://docs.open-metadata.org/connectors/metadata/amundsen`