### PR TITLE
update the get started url and fix the scroll

### DIFF
--- a/src/components/NavbarDev/NavbarStrip.component.tsx
+++ b/src/components/NavbarDev/NavbarStrip.component.tsx
@@ -19,7 +19,7 @@ const NavbarStrip = () => {
         <span className="lg:relative">
           <Link
             className="border-1 border-[#D3ECF7] px-4 py-2 lg:text-[24px] leading-[31.2px] hover:text-[#D3ECF7]"
-            href="https://cloud.getcollate.io/"
+            href="https://cloud.getcollate.io/signup"
             target="_blank"
           >
             Get Started

--- a/src/components/Testimonials/Testimonials.tsx
+++ b/src/components/Testimonials/Testimonials.tsx
@@ -78,14 +78,14 @@ const Testimonials = () => {
     <div className="custom-container relative z-[12]">
       <div className="flex justify-between">
         <Image
-          className="hidden mt-5 lg:block"
+          className="hidden lg:block"
           height={20}
           width={140}
           src="/assets/header/left-box.svg"
           alt="left-box-svg"
           loading="lazy"
         />
-        <div className="mt-32 mx-auto px-4 md:px-16 lg:px-0">
+        <div className="mt-28 mx-auto px-4 md:px-16 lg:px-0">
           <h3 className="text-[#292929] font-medium text-center text-[36px] lg:text-[44px]">
             Trusted <span className="text-[#7147E8]">Across Industries</span>
           </h3>

--- a/src/components/TryOpenMetadata/TryOpenMetadata.tsx
+++ b/src/components/TryOpenMetadata/TryOpenMetadata.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 const TryOpenMetadata = () => {
   return (
     <div className="shadow-bg mt-20" id="try-openmetadata">
-      <div className="custom-container pt-16 px-4 md:px-16">
+      <div className="custom-container py-16 px-4 md:px-16">
         <h3 className="text-[#292929] font-medium text-center text-[36px] lg:text-[44px]">
           Different ways to try out{" "}
           <span className="text-[#7147E8]">OpenMetadata</span>

--- a/src/pages/development.tsx
+++ b/src/pages/development.tsx
@@ -14,7 +14,7 @@ import Head from "next/head";
 const Development = () => {
   const handleTryOpenMetadataClick = () => {
     const element = document.querySelector("#try-openmetadata");
-    element?.scrollIntoView({ behavior: "smooth", block: "center" })
+    element?.scrollIntoView({ behavior: "smooth", block: "end" })
   }
 
   return (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -53,6 +53,12 @@ p{
   @apply bg-gradient-to-b from-[#F1EDFD] to-white
 }
 
+@media (max-width: 767px) {
+  .slick-slider .slick-dots li {
+    margin: 0 0.2rem;
+  }
+}
+
 @media (min-width: 576px) {
   .container-sm,
   .container {


### PR DESCRIPTION
Update the URL in which the get Started button will lead to and updated the scroll part on click of try openmetadata button.
<img width="720" alt="image" src="https://github.com/open-metadata/openmetadata-site/assets/105535990/03d3a51b-98a4-4b01-a964-181e21f7874e">
<img width="197" alt="image" src="https://github.com/open-metadata/openmetadata-site/assets/105535990/086ea2a2-bbcb-44a5-b568-02bad1ea83cc">
Reduced the gap between the dots for mobile view so that they won't overflow from the screen.