### PR TITLE
Update padding for try openmetadata

### DIFF
--- a/src/components/Achievement/Achievement.tsx
+++ b/src/components/Achievement/Achievement.tsx
@@ -37,7 +37,7 @@ const Achievement = () => {
                   <div className="text-[#382374] tracking-wider font-bold sm:text-[32px] lg:text-[32px]">
                     {item.count}+
                   </div>
-                  <div className="uppercase text-[#555555] font-normal max-w-[78%] sm:tracking-[0.2em]">
+                  <div className="uppercase text-[#555555] font-normal leading-[20px] max-w-[78%] sm:tracking-[0.2em]">
                     {item.name}
                   </div>
                 </div>

--- a/src/components/TryOpenMetadata/TryOpenMetadata.tsx
+++ b/src/components/TryOpenMetadata/TryOpenMetadata.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 const TryOpenMetadata = () => {
   return (
     <div className="shadow-bg mt-20" id="try-openmetadata">
-      <div className="custom-container py-16 px-4 md:px-16">
+      <div className="custom-container py-16 px-4 md:px-16 xl:px-32">
         <h3 className="text-[#292929] font-medium tracking-[-0.02em] text-center text-[36px] lg:text-[48px]">
           Different ways to try out{" "}
           <span className="text-[#7147E8]">OpenMetadata</span>


### PR DESCRIPTION
Updated padding as per new design.
<img width="1440" alt="image" src="https://github.com/open-metadata/openmetadata-site/assets/105535990/93dd8d27-1a0b-4880-9593-f091cca3aadf">
