### PR TITLE
fix: replace mobile connectors dropdown with accordion layout

### DIFF
--- a/src/components/IntegrationsDev/IntegrationsDev.tsx
+++ b/src/components/IntegrationsDev/IntegrationsDev.tsx
@@ -66,12 +66,12 @@ const IntegrationsDev = () => {
       <div className="mt-[48px] overflow-y-scroll relative shadow-primary rounded-lg md:rounded-2xl sm:flex sm:h-[974px] md:h-[1044px]">
         <button
           onClick={() => setIsDropdownVisible((prev) => !prev)}
-          className="py-[32px] w-full sticky top-0 bg-white z-[15] flex items-center border-b border-[#E3DAFA] justify-center gap-2 text-[#5E3BC1] text-[20px] font-normal tracking-[-0.02em] sm:hidden"
+          className="py-[32px] w-full bg-white z-[15] flex items-center border-b border-[#E3DAFA] justify-center gap-2 text-[#5E3BC1] text-[20px] font-normal tracking-[-0.02em] sm:hidden"
         >
           <span>{selectedTab}</span>
           <svg
             className={`${
-              isDropdownVisible ? 'rotate-180' : ''
+              isDropdownVisible ? "rotate-180" : ""
             } transition-all duration-300`}
             width="19"
             height="12"
@@ -90,15 +90,17 @@ const IntegrationsDev = () => {
         </button>
         <div
           className={`${
-            isDropdownVisible ? 'block' : 'hidden'
-          } integration w-full absolute flex flex-col bg-white text-[#5E3BC1] text-[20px] text-center sm:w-auto sm:block sm:relative sm:text-[16px] sm:border-[#E3DAFA] sm:border-r md:text-[20px] sm:rounded-l-lg md:rounded-l-2xl lg:max-w-[20%] xl:max-w-[25%]`}
+            isDropdownVisible
+              ? "max-h-[500px] overflow-y-auto"
+              : "max-h-0 overflow-hidden"
+          } transition-all duration-300 integration w-full flex flex-col bg-white text-[#5E3BC1] text-[20px] text-center sm:w-auto sm:block sm:relative sm:max-h-full sm:overflow-visible sm:text-[16px] sm:border-[#E3DAFA] sm:border-r md:text-[20px] sm:rounded-l-lg md:rounded-l-2xl lg:max-w-[20%] xl:max-w-[25%]`}
         >
           <div
             className={`px-5 py-[28px] cursor-pointer tracking-[-0.02em] text-nowrap ${
-              selectedTab === 'All Connectors' &&
-              'font-semibold bg-[#EDF3FD] sm:rounded-tl-lg md:rounded-tl-2xl'
-            } border-b border-[#E3DAFA] lg:px-9 xl:px-12`}
-            onClick={() => handleTabClick('All Connectors')}
+              selectedTab === "All Connectors" &&
+              "font-semibold bg-[#EDF3FD] sm:rounded-tl-lg md:rounded-tl-2xl"
+            } border-b border-[#E3DAFA] lg:px-9 xl:px-12 sm:block hidden`}
+            onClick={() => handleTabClick("All Connectors")}
           >
             All Connectors
           </div>
@@ -107,13 +109,13 @@ const IntegrationsDev = () => {
               key={service.connector}
               className={`px-5 py-[28px] tracking-[-0.02em] cursor-pointer ${
                 selectedTab === service.connector &&
-                'font-semibold bg-[#EDF3FD]'
+                "font-semibold bg-[#EDF3FD]"
               } ${
-                selectedTab === 'Others' &&
-                service.connector === 'Others' &&
-                'sm:rounded-tr-lg md:rounded-bl-2xl'
+                selectedTab === "Others" &&
+                service.connector === "Others" &&
+                "sm:rounded-tr-lg md:rounded-bl-2xl"
               } ${
-                service.connector === 'Others' && 'sm:border-none'
+                service.connector === "Others" && "sm:border-none"
               } border-b border-[#E3DAFA] lg:px-9 xl:px-12`}
               onClick={() => handleTabClick(service.connector)}
             >
@@ -124,12 +126,11 @@ const IntegrationsDev = () => {
         <div className="py-8 px-3 gap-[6px] w-full hidden overflow-y-scroll justify-center justify-items-center gap-y-6 sm:px-8 sm:grid grid-cols-2 sm:auto-rows-max md:grid-cols-3 lg:grid-cols-5 lg:px-9 xl:grid-cols-6">
           {services.map((item) => (
             <div key={item.name} className="max-h-[110px]">
-              <ParamLink
-                href={item.href ?? '#'}
-                target="_blank"
-              >
+              <ParamLink href={item.href ?? "#"} target="_blank">
                 <div className="text-center flex flex-col items-center self-center">
-                  <div className={`relative ${item.name=== 'Exasol' || item.name.includes('SAP') ? 'h-[15px] mt-3' : 'h-[57px]'} w-[57px]`}>
+                  <div
+                    className={`relative ${item.name === "Exasol" || item.name.includes("SAP") ? "h-[15px] mt-3" : "h-[57px]"} w-[57px]`}
+                  >
                     <Image
                       alt={item.alt}
                       src={item.src}
@@ -137,13 +138,15 @@ const IntegrationsDev = () => {
                       fill
                       sizes="500px"
                       style={{
-                        objectFit: 'contain',
+                        objectFit: "contain",
                       }}
                     />
                   </div>
-                <p className={`${item.name === 'Exasol' || item.name.includes('SAP') ? 'mt-8' : 'mt-2'} text-nowrap text-[14px] sm:text-wrap md:text-[16px]`}>
-                  {item.name}
-                </p>
+                  <p
+                    className={`${item.name === "Exasol" || item.name.includes("SAP") ? "mt-8" : "mt-2"} text-nowrap text-[14px] sm:text-wrap md:text-[16px]`}
+                  >
+                    {item.name}
+                  </p>
                 </div>
               </ParamLink>
             </div>


### PR DESCRIPTION
## Problem
On mobile screens, the "All Connectors" dropdown was using absolute positioning inside an overflow-y-scroll container, causing the category list to overlap the connector icons below it.

Related issue: #340

## Fix
- Removed `sticky` and `absolute` positioning from the mobile dropdown
- Replaced `block/hidden` toggle with `max-h` based accordion animation
- "All Connectors" item hidden on mobile (redundant as it is the button label)
- Desktop layout (sm: and above) is completely unchanged

## Testing
Tested on Samsung Galaxy A51/71 viewport (412px) in Chrome DevTools.
Desktop view verified unchanged.

## Screenshots
> Attached screenshots after testing

> <img width="483" height="433" alt="all-connectors-mobile-view" src="https://github.com/user-attachments/assets/83fe6ecd-8c04-41e3-9732-c58586054cb9" />

> <img width="489" height="433" alt="mobile-view-samsung-a5" src="https://github.com/user-attachments/assets/c7edac3e-0d29-42d8-9a91-2c3e79af7d1d" />