### PR TITLE
Add Collate Summit '26 announcement banner

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,0 +1,25 @@
+import { useRouter } from "next/router";
+import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
+import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
+
+const Layout = ({ children }: { children: React.ReactNode }) => {
+  const router = useRouter();
+
+  const handleTryOpenMetadataClick = () => {
+    router.push("/#try-openmetadata");
+  };
+
+  return (
+    <>
+      <div className="mx-auto fixed top-0 w-full z-[1030]">
+        <SummitBanner />
+        <NavbarDev onClick={handleTryOpenMetadataClick} />
+        <NavbarStrip />
+      </div>
+      {children}
+    </>
+  );
+};
+
+export default Layout;

--- a/src/components/NavbarDev/SummitBanner.component.tsx
+++ b/src/components/NavbarDev/SummitBanner.component.tsx
@@ -2,8 +2,8 @@ import ParamLink from "../ParamLink";
 
 const SummitBanner = () => {
   return (
-    <div className="w-full py-1 px-5 bg-[#0B3547] text-center">
-      <span className="text-sm font-normal text-white">
+    <div className="w-full py-[6px] px-5 text-center" style={{ background: "linear-gradient(270deg, #ECE5FF 39.9%, #7147E8 114.41%)" }}>
+      <span className="text-black text-sm font-medium">
         OpenMetadata production stories from OpenAI, Yelp, Rakuten &amp; more —{" "}
         <ParamLink
           name="Register Now for Collate Summit '26"

--- a/src/components/NavbarDev/SummitBanner.component.tsx
+++ b/src/components/NavbarDev/SummitBanner.component.tsx
@@ -4,9 +4,9 @@ const SummitBanner = () => {
   return (
     <div className="w-full py-1 px-5 bg-[#0B3547] text-center">
       <span className="text-sm font-normal text-white">
-        Collate Summit &apos;26: OpenMetadata deployment stories from OpenAI, Airbus, Scout24, Rakuten &amp; more —{" "}
+        OpenMetadata production stories from OpenAI, Yelp, Rakuten &amp; more —{" "}
         <ParamLink
-          name="Register Now"
+          name="Register Now for Collate Summit '26"
           href="https://www.getcollate.io/summit2026"
           target="_blank"
           className="underline"

--- a/src/components/NavbarDev/SummitBanner.component.tsx
+++ b/src/components/NavbarDev/SummitBanner.component.tsx
@@ -3,7 +3,7 @@ import ParamLink from "../ParamLink";
 const SummitBanner = () => {
   return (
     <div className="w-full py-[6px] px-5 text-center" style={{ background: "linear-gradient(270deg, #ECE5FF 39.9%, #7147E8 114.41%)" }}>
-      <span className="text-black text-sm font-medium">
+      <span className="text-black text-sm">
         OpenMetadata production stories from OpenAI, Yelp, Rakuten &amp; more —{" "}
         <ParamLink
           name="Register Now for Collate Summit '26"

--- a/src/components/NavbarDev/SummitBanner.component.tsx
+++ b/src/components/NavbarDev/SummitBanner.component.tsx
@@ -1,0 +1,20 @@
+import ParamLink from "../ParamLink";
+
+const SummitBanner = () => {
+  return (
+    <div className="w-full py-1 px-5 bg-[#0B3547] text-center">
+      <span className="text-sm font-normal text-white">
+        Collate Summit &apos;26: OpenMetadata deployment stories from OpenAI, Airbus, Scout24, Rakuten &amp; more —{" "}
+        <ParamLink
+          name="Register Now"
+          href="https://www.getcollate.io/summit2026"
+          target="_blank"
+          className="underline"
+        />{" "}
+        🚀
+      </span>
+    </div>
+  );
+};
+
+export default SummitBanner;

--- a/src/components/NavbarDev/SummitBanner.component.tsx
+++ b/src/components/NavbarDev/SummitBanner.component.tsx
@@ -9,7 +9,7 @@ const SummitBanner = () => {
           name="Register Now for Collate Summit '26"
           href="https://www.getcollate.io/summit2026"
           target="_blank"
-          className="underline"
+          className="underline font-semibold"
         />{" "}
         🚀
       </span>

--- a/src/components/TryOpenMetadata/TryOpenMetadata.tsx
+++ b/src/components/TryOpenMetadata/TryOpenMetadata.tsx
@@ -4,7 +4,7 @@ import ParamLink from "../ParamLink";
 
 const TryOpenMetadata = () => {
   return (
-    <div className="shadow-bg mt-20" id="try-openmetadata">
+    <div className="shadow-bg mt-20 scroll-mt-32" id="try-openmetadata">
       <div className="custom-container py-16 px-4 md:px-16 xl:px-32">
         <h3 className="text-[#292929] font-medium tracking-[-0.02em] text-center text-[32px] leading-[40px] max-w-[85%] mx-auto lg:text-[48px]">
           Different ways to try out{" "}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,6 +15,7 @@ import "aos/dist/aos.css";
 import { useEffect, useState } from "react";
 import Head from "next/head";
 import CookieModal from "@/components/CookieModal";
+import Layout from "@/components/Layout/Layout";
 
 config.autoAddCss = false;
 
@@ -136,8 +137,10 @@ export default function App({ Component, pageProps }: AppProps) {
           </>
         )}
       </Head>
-      {!storedCookie && <CookieModal handleButtonClick={handleButtonClick} />}
-      <Component {...pageProps} />
+      <Layout>
+        {!storedCookie && <CookieModal handleButtonClick={handleButtonClick} />}
+        <Component {...pageProps} />
+      </Layout>
     </>
   );
 }

--- a/src/pages/case-studies.tsx
+++ b/src/pages/case-studies.tsx
@@ -1,8 +1,5 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
 import HubspotForm from "@/components/HubspotForm";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import ParamLink from "@/components/ParamLink";
 import {
   CUSTOMER_GALLERY,
@@ -10,7 +7,6 @@ import {
   INDUSTRY_LIST,
 } from "@/constants/CustomerGallery.constants";
 import Image from "next/image";
-import { useRouter } from "next/router";
 import { useState } from "react";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
@@ -22,15 +18,10 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const CaseStudiesPage = () => {
-  const router = useRouter();
   const [activeIndustry, setActiveIndustry] = useState<string>("All");
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
   const [customers, setCustomers] = useState(CUSTOMER_GALLERY);
   const [inputValue, setInputValue] = useState<string>("");
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
 
   const handleIndustryFilter = (industry: string) => {
     setInputValue("");
@@ -59,11 +50,6 @@ const CaseStudiesPage = () => {
 
   return (
     <div>
-      <div className="mx-auto fixed top-0 w-full z-[1030]">
-        <SummitBanner />
-        <NavbarDev onClick={handleTryOpenMetadataClick} />
-        <NavbarStrip />
-      </div>
       <div className="mt-20 md:mt-24 lg:mt-32">
         <div className="case-study-page">
           <div className="max-w-[1440px] mx-auto py-28 md:py-20 px-5 md:px-10 xl:px-20">

--- a/src/pages/case-studies.tsx
+++ b/src/pages/case-studies.tsx
@@ -2,6 +2,7 @@ import FooterDev from "@/components/FooterDev/FooterDev";
 import HubspotForm from "@/components/HubspotForm";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import ParamLink from "@/components/ParamLink";
 import {
   CUSTOMER_GALLERY,
@@ -59,6 +60,7 @@ const CaseStudiesPage = () => {
   return (
     <div>
       <div className="mx-auto fixed top-0 w-full z-[1030]">
+        <SummitBanner />
         <NavbarDev onClick={handleTryOpenMetadataClick} />
         <NavbarStrip />
       </div>

--- a/src/pages/case-study/aspire.tsx
+++ b/src/pages/case-study/aspire.tsx
@@ -2,17 +2,13 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { 
+import {
     ASPIRE_CUSTOMER_CHALLENGES, 
     ASPIRE_CUSTOMER_HEADER, 
     ASPIRE_CUSTOMER_HIGHLIGHTS, 
     ASPIRE_CUSTOMER_TESTIMONIAL 
 } from "@/constants/AspireCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const AspireCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -36,11 +26,6 @@ const AspireCaseStudyPage = () => {
         <meta name="description" content="Learn how Aspire unified metadata across its finance platform using OpenMetadata, replacing manual documentation with a trusted system of record, standardizing data quality, and enabling faster, self-serve analytics across 1,700+ tables and 6,100+ quality checks." />
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={ASPIRE_CUSTOMER_HEADER}

--- a/src/pages/case-study/aspire.tsx
+++ b/src/pages/case-study/aspire.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { 
     ASPIRE_CUSTOMER_CHALLENGES, 
     ASPIRE_CUSTOMER_HEADER, 
@@ -36,6 +37,7 @@ const AspireCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/carrefour-brazil.tsx
+++ b/src/pages/case-study/carrefour-brazil.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import {
   CARREFOUR_CUSTOMER_CHALLENGES,
   CARREFOUR_CUSTOMER_HEADER,
@@ -37,6 +38,7 @@ const CarrefourCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/carrefour-brazil.tsx
+++ b/src/pages/case-study/carrefour-brazil.tsx
@@ -2,9 +2,6 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import {
   CARREFOUR_CUSTOMER_CHALLENGES,
   CARREFOUR_CUSTOMER_HEADER,
@@ -12,7 +9,6 @@ import {
   CARREFOUR_CUSTOMER_TESTIMONIAL,
 } from "@/constants/CarrefourCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const CarrefourCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -37,11 +27,6 @@ const CarrefourCaseStudyPage = () => {
         </title>
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={CARREFOUR_CUSTOMER_HEADER}

--- a/src/pages/case-study/forter.tsx
+++ b/src/pages/case-study/forter.tsx
@@ -2,17 +2,13 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { 
+import {
     FORTER_CUSTOMER_CHALLENGES, 
     FORTER_CUSTOMER_HEADER, 
     FORTER_CUSTOMER_HIGHLIGHTS, 
     FORTER_CUSTOMER_TESTIMONIAL 
 } from "@/constants/ForterCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const ForterCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -36,11 +26,6 @@ const ForterCaseStudyPage = () => {
         <meta name="description" content="Discover how Forter built a centralized metadata foundation to manage sensitive, high-volume data while deterring malicious behavior for enterprise merchants." />
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={FORTER_CUSTOMER_HEADER}

--- a/src/pages/case-study/forter.tsx
+++ b/src/pages/case-study/forter.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { 
     FORTER_CUSTOMER_CHALLENGES, 
     FORTER_CUSTOMER_HEADER, 
@@ -36,6 +37,7 @@ const ForterCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/freenow.tsx
+++ b/src/pages/case-study/freenow.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { 
     FREENOW_CUSTOMER_CHALLENGES, 
     FREENOW_CUSTOMER_HEADER, 
@@ -39,6 +40,7 @@ const FreeNowCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/freenow.tsx
+++ b/src/pages/case-study/freenow.tsx
@@ -2,17 +2,13 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { 
+import {
     FREENOW_CUSTOMER_CHALLENGES, 
     FREENOW_CUSTOMER_HEADER, 
     FREENOW_CUSTOMER_HIGHLIGHTS, 
     FREENOW_CUSTOMER_TESTIMONIAL 
 } from "@/constants/FreenowCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const FreeNowCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -39,11 +29,6 @@ const FreeNowCaseStudyPage = () => {
         />
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={FREENOW_CUSTOMER_HEADER}

--- a/src/pages/case-study/gorgias.tsx
+++ b/src/pages/case-study/gorgias.tsx
@@ -2,9 +2,6 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import {
   GORGIAS_CUSTOMER_CHALLENGES,
   GORGIAS_CUSTOMER_HEADER,
@@ -12,7 +9,6 @@ import {
   GORGIAS_CUSTOMER_TESTIMONIAL,
 } from "@/constants/GorgiasCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,23 +19,12 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const GorgiasCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
         <title>Gorgias: Data Discovery Automation with OpenMetadata</title>
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={GORGIAS_CUSTOMER_HEADER}

--- a/src/pages/case-study/gorgias.tsx
+++ b/src/pages/case-study/gorgias.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import {
   GORGIAS_CUSTOMER_CHALLENGES,
   GORGIAS_CUSTOMER_HEADER,
@@ -35,6 +36,7 @@ const GorgiasCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/indrive.tsx
+++ b/src/pages/case-study/indrive.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { 
     INDRIVE_CUSTOMER_CHALLENGES, 
     INDRIVE_CUSTOMER_HEADER, 
@@ -36,6 +37,7 @@ const IndriveCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/indrive.tsx
+++ b/src/pages/case-study/indrive.tsx
@@ -2,17 +2,13 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { 
+import {
     INDRIVE_CUSTOMER_CHALLENGES, 
     INDRIVE_CUSTOMER_HEADER, 
     INDRIVE_CUSTOMER_HIGHLIGHTS, 
     INDRIVE_CUSTOMER_TESTIMONIAL 
 } from "@/constants/IndriveCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const IndriveCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -36,11 +26,6 @@ const IndriveCaseStudyPage = () => {
         <meta name="description" content="See how inDrive tracks and governs 100+ AWS-hosted databases for global teams, enabling faster analytics, automated compliance, and trusted data at scale." />
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={INDRIVE_CUSTOMER_HEADER}

--- a/src/pages/case-study/kansai-airports.tsx
+++ b/src/pages/case-study/kansai-airports.tsx
@@ -2,17 +2,13 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { 
+import {
     KANSAI_CUSTOMER_CHALLENGES, 
     KANSAI_CUSTOMER_HEADER, 
     KANSAI_CUSTOMER_HIGHLIGHTS, 
     KANSAI_CUSTOMER_TESTIMONIAL 
 } from "@/constants/KansaiAirportCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const KansaiCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -36,11 +26,6 @@ const KansaiCaseStudyPage = () => {
         <meta name="description" content="Discover how Kansai Airports modernized its aviation data operations, breaking down silos across dashboards and systems, reducing metadata management effort by 67%, and enabling faster, trusted insights for 50M+ passengers annually." />
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={KANSAI_CUSTOMER_HEADER}

--- a/src/pages/case-study/kansai-airports.tsx
+++ b/src/pages/case-study/kansai-airports.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { 
     KANSAI_CUSTOMER_CHALLENGES, 
     KANSAI_CUSTOMER_HEADER, 
@@ -36,6 +37,7 @@ const KansaiCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/loggi.tsx
+++ b/src/pages/case-study/loggi.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { 
   LOGGI_CUSTOMER_CHALLENGES, 
   LOGGI_CUSTOMER_HEADER, 
@@ -36,6 +37,7 @@ const LoggiCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/loggi.tsx
+++ b/src/pages/case-study/loggi.tsx
@@ -2,17 +2,13 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { 
+import {
   LOGGI_CUSTOMER_CHALLENGES, 
   LOGGI_CUSTOMER_HEADER, 
   LOGGI_CUSTOMER_HIGHLIGHTS, 
   LOGGI_CUSTOMER_TESTIMONIAL 
 } from "@/constants/LoggiCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const LoggiCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -36,11 +26,6 @@ const LoggiCaseStudyPage = () => {
         <meta name="description" content="Loggi saves $24K annually with OpenMetadata. Cut dashboards from 18K  to 2K with streamlined data governance" />
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={LOGGI_CUSTOMER_HEADER}

--- a/src/pages/case-study/nw.tsx
+++ b/src/pages/case-study/nw.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { 
     NW_CUSTOMER_CHALLENGES, 
     NW_CUSTOMER_HEADER, 
@@ -36,6 +37,7 @@ const NwCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/nw.tsx
+++ b/src/pages/case-study/nw.tsx
@@ -2,17 +2,13 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { 
+import {
     NW_CUSTOMER_CHALLENGES, 
     NW_CUSTOMER_HEADER, 
     NW_CUSTOMER_HIGHLIGHTS, 
     NW_CUSTOMER_TESTIMONIAL 
 } from "@/constants/NwCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const NwCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -36,11 +26,6 @@ const NwCaseStudyPage = () => {
         <meta name="description" content="See how NW implemented OpenMetadata to centralize governance: automating lineage, enriching metadata, and scaling insights across 90+ connectors." />
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={NW_CUSTOMER_HEADER}

--- a/src/pages/case-study/thndr.tsx
+++ b/src/pages/case-study/thndr.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { 
     THNDR_CUSTOMER_CHALLENGES, 
     THNDR_CUSTOMER_HEADER, 
@@ -36,6 +37,7 @@ const ThndrCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/thndr.tsx
+++ b/src/pages/case-study/thndr.tsx
@@ -2,17 +2,13 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { 
+import {
     THNDR_CUSTOMER_CHALLENGES, 
     THNDR_CUSTOMER_HEADER, 
     THNDR_CUSTOMER_HIGHLIGHTS, 
     THNDR_CUSTOMER_TESTIMONIAL 
 } from "@/constants/ThndrCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const ThndrCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -36,11 +26,6 @@ const ThndrCaseStudyPage = () => {
         <meta name="description" content="See how fintech Thndr's 6-person data team scales governance for 3M+ investor accounts with OpenMetadata's automated PII detection and real-time quality monitoring" />
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={THNDR_CUSTOMER_HEADER}

--- a/src/pages/case-study/vrt.tsx
+++ b/src/pages/case-study/vrt.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { 
     VRT_CUSTOMER_CHALLENGES, 
     VRT_CUSTOMER_HEADER, 
@@ -36,6 +37,7 @@ const VRTCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/vrt.tsx
+++ b/src/pages/case-study/vrt.tsx
@@ -2,17 +2,13 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { 
+import {
     VRT_CUSTOMER_CHALLENGES, 
     VRT_CUSTOMER_HEADER, 
     VRT_CUSTOMER_HIGHLIGHTS, 
     VRT_CUSTOMER_TESTIMONIAL 
 } from "@/constants/VRTCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const VRTCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -36,11 +26,6 @@ const VRTCaseStudyPage = () => {
         <meta name="description" content="Discover how Belgian public media broadcaster VRT established true ownership of data quality fixes at scale through their data transformation partners at Dataroots and OpenMetadata!" />
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={VRT_CUSTOMER_HEADER}

--- a/src/pages/case-study/wix.tsx
+++ b/src/pages/case-study/wix.tsx
@@ -2,17 +2,13 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { 
+import {
     WIX_CUSTOMER_CHALLENGES, 
     WIX_CUSTOMER_HEADER, 
     WIX_CUSTOMER_HIGHLIGHTS, 
     WIX_CUSTOMER_TESTIMONIAL 
 } from "@/constants/WixCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const WixCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -36,11 +26,6 @@ const WixCaseStudyPage = () => {
         <meta name="description" content="Discover how Wix leverages OpenMetadata to deliver real-time insights, streamline analyst work, and power AI agents that drive faster product decisions for 200M+ users." />
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={WIX_CUSTOMER_HEADER}

--- a/src/pages/case-study/wix.tsx
+++ b/src/pages/case-study/wix.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { 
     WIX_CUSTOMER_CHALLENGES, 
     WIX_CUSTOMER_HEADER, 
@@ -36,6 +37,7 @@ const WixCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/case-study/woop.tsx
+++ b/src/pages/case-study/woop.tsx
@@ -2,17 +2,13 @@ import CustomerChallenges from "@/components/CustomerCaseStudy/CustomerChallenge
 import CustomerHeader from "@/components/CustomerCaseStudy/CustomerHeader";
 import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimonial";
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { 
+import {
   WOOP_CUSTOMER_CHALLENGES, 
   WOOP_CUSTOMER_HEADER, 
   WOOP_CUSTOMER_HIGHLIGHTS, 
   WOOP_CUSTOMER_TESTIMONIAL 
 } from "@/constants/WoopCustomer.constants";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -23,12 +19,6 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const WoopCaseStudyPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <>
       <Head>
@@ -36,11 +26,6 @@ const WoopCaseStudyPage = () => {
         <meta name="description" content="See how logistics platform Woop's 2-person data team manages 1,600+ assets for 100+ users with OpenMetadata's automated governance and self-service discovery." />
       </Head>
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <div className="mt-20 md:mt-24 lg:mt-32">
           <CustomerHeader
             customerHeader={WOOP_CUSTOMER_HEADER}

--- a/src/pages/case-study/woop.tsx
+++ b/src/pages/case-study/woop.tsx
@@ -4,6 +4,7 @@ import CustomerTestimonial from "@/components/CustomerCaseStudy/CustomerTestimon
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { 
   WOOP_CUSTOMER_CHALLENGES, 
   WOOP_CUSTOMER_HEADER, 
@@ -36,6 +37,7 @@ const WoopCaseStudyPage = () => {
       </Head>
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -1,6 +1,7 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import ParamLink from "@/components/ParamLink";
 import YoutubeEmbed from "@/components/common/YouTubeEmbed";
 import Image from "next/image";
@@ -25,6 +26,7 @@ export default function Community() {
       <div id="layoutDefault">
         <div id="layoutDefault_content">
           <div className="mx-auto fixed top-0 w-full z-[1030]">
+            <SummitBanner />
             <NavbarDev onClick={handleTryOpenMetadataClick} />
             <NavbarStrip />
           </div>

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -1,11 +1,7 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import ParamLink from "@/components/ParamLink";
 import YoutubeEmbed from "@/components/common/YouTubeEmbed";
 import Image from "next/image";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -16,21 +12,9 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 export default function Community() {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
       <div id="layoutDefault">
         <div id="layoutDefault_content">
-          <div className="mx-auto fixed top-0 w-full z-[1030]">
-            <SummitBanner />
-            <NavbarDev onClick={handleTryOpenMetadataClick} />
-            <NavbarStrip />
-          </div>
-
           <header className="page-header-ui page-header-ui-light bg-white lg:pt-32 max-lg:mt-0">
             <div className="page-header-ui-content pt-5 max-lg:pt-0">
               <div className="container px-10">

--- a/src/pages/cve-list.tsx
+++ b/src/pages/cve-list.tsx
@@ -1,6 +1,7 @@
 import FooterDev from '@/components/FooterDev/FooterDev';
 import NavbarDev from '@/components/NavbarDev/NavbarDev.component';
 import NavbarStrip from '@/components/NavbarDev/NavbarStrip.component';
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { useRouter } from 'next/router';
 import React from 'react';
 
@@ -24,6 +25,7 @@ const CSVList = () => {
   return (
     <div id="layoutDefault">
       <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/cve-list.tsx
+++ b/src/pages/cve-list.tsx
@@ -1,8 +1,4 @@
 import FooterDev from '@/components/FooterDev/FooterDev';
-import NavbarDev from '@/components/NavbarDev/NavbarDev.component';
-import NavbarStrip from '@/components/NavbarDev/NavbarStrip.component';
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
-import { useRouter } from 'next/router';
 import React from 'react';
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
@@ -15,20 +11,8 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const CSVList = () => {
-
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push('/#try-openmetadata');
-  }
-
   return (
     <div id="layoutDefault">
-      <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
       <div className="right openmetadata-container mx-auto mt-36">
         <h1 className="text-2xl lg:text-4xl font-bold mb-4">
           OpenMetadata Security Vulnerabilities

--- a/src/pages/datacontracts.tsx
+++ b/src/pages/datacontracts.tsx
@@ -1,6 +1,7 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import ParamLink from "@/components/ParamLink";
 import YoutubeEmbed from "@/components/common/YouTubeEmbed";
 import Image from "next/image";
@@ -26,6 +27,7 @@ export default function Community() {
       <div id="layoutDefault">
         <div id="layoutDefault_content">
           <div className="mx-auto fixed top-0 w-full z-[1030]">
+            <SummitBanner />
             <NavbarDev onClick={handleTryOpenMetadataClick} />
             <NavbarStrip />
           </div>

--- a/src/pages/datacontracts.tsx
+++ b/src/pages/datacontracts.tsx
@@ -1,12 +1,7 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import ParamLink from "@/components/ParamLink";
 import YoutubeEmbed from "@/components/common/YouTubeEmbed";
 import Image from "next/image";
-import { useRouter } from "next/router";
-
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
     props: {
@@ -16,22 +11,10 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 export default function Community() {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <div className="justify-between min-h-screen flex flex-col">
       <div id="layoutDefault">
         <div id="layoutDefault_content">
-          <div className="mx-auto fixed top-0 w-full z-[1030]">
-            <SummitBanner />
-            <NavbarDev onClick={handleTryOpenMetadataClick} />
-            <NavbarStrip />
-          </div>
-
           <header className="page-header-ui page-header-ui-light bg-white lg:pt-32 max-lg:mt-0">
             <div className="page-header-ui-content pt-5 max-lg:pt-0">
               <div className="container px-10">

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -1,6 +1,7 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import ParamLink from "@/components/ParamLink";
 import YoutubeEmbed from "@/components/common/YouTubeEmbed";
 import { useRouter } from "next/router";
@@ -24,6 +25,7 @@ export default function Events() {
     <div id="layoutDefault">
       <div id="layoutDefault_content">
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -1,10 +1,6 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import ParamLink from "@/components/ParamLink";
 import YoutubeEmbed from "@/components/common/YouTubeEmbed";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -15,21 +11,9 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 export default function Events() {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <div id="layoutDefault">
       <div id="layoutDefault_content">
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
-
         <section className="bg-white lg:pt-40 max-lg:pt-24 pt-20">
           <div className="container px-10 py-10">
             <div className="text-center mb-8 max-w-4xl mx-auto">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,9 +4,6 @@ import FooterDev from "@/components/FooterDev/FooterDev";
 import Header from "@/components/Header/Header";
 import IntegrationsDev from "@/components/IntegrationsDev/IntegrationsDev";
 import KeyDataAssets from "@/components/KeyDataAssets/KeyDataAssets";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import Services from "@/components/Service/Service";
 import Testimonials from "@/components/Testimonials/Testimonials";
 import TryOpenMetadata from "@/components/TryOpenMetadata/TryOpenMetadata";
@@ -27,11 +24,6 @@ const Development = () => {
 
   return (
       <div>
-        <div className="mx-auto fixed top-0 w-full z-[1030]">
-          <SummitBanner />
-          <NavbarDev onClick={handleTryOpenMetadataClick} />
-          <NavbarStrip />
-        </div>
         <Header onClick={handleTryOpenMetadataClick} />
         <Achievement />
         <Services />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,6 +6,7 @@ import IntegrationsDev from "@/components/IntegrationsDev/IntegrationsDev";
 import KeyDataAssets from "@/components/KeyDataAssets/KeyDataAssets";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import Services from "@/components/Service/Service";
 import Testimonials from "@/components/Testimonials/Testimonials";
 import TryOpenMetadata from "@/components/TryOpenMetadata/TryOpenMetadata";
@@ -27,6 +28,7 @@ const Development = () => {
   return (
       <div>
         <div className="mx-auto fixed top-0 w-full z-[1030]">
+          <SummitBanner />
           <NavbarDev onClick={handleTryOpenMetadataClick} />
           <NavbarStrip />
         </div>

--- a/src/pages/mcp.tsx
+++ b/src/pages/mcp.tsx
@@ -1,6 +1,7 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import ParamLink from "@/components/ParamLink";
 import YoutubeEmbed from "@/components/common/YouTubeEmbed";
 import Image from "next/image";
@@ -26,6 +27,7 @@ export default function Community() {
       <div id="layoutDefault">
         <div id="layoutDefault_content">
           <div className="mx-auto fixed top-0 w-full z-[1030]">
+            <SummitBanner />
             <NavbarDev onClick={handleTryOpenMetadataClick} />
             <NavbarStrip />
           </div>

--- a/src/pages/mcp.tsx
+++ b/src/pages/mcp.tsx
@@ -1,12 +1,7 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import ParamLink from "@/components/ParamLink";
 import YoutubeEmbed from "@/components/common/YouTubeEmbed";
 import Image from "next/image";
-import { useRouter } from "next/router";
-
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
     props: {
@@ -16,22 +11,10 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 export default function Community() {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <div className="justify-between min-h-screen flex flex-col">
       <div id="layoutDefault">
         <div id="layoutDefault_content">
-          <div className="mx-auto fixed top-0 w-full z-[1030]">
-            <SummitBanner />
-            <NavbarDev onClick={handleTryOpenMetadataClick} />
-            <NavbarStrip />
-          </div>
-
           <header className="page-header-ui page-header-ui-light bg-white lg:pt-32 max-lg:mt-0">
             <div className="page-header-ui-content pt-5 max-lg:pt-0">
               <div className="container px-10">

--- a/src/pages/product-updates.tsx
+++ b/src/pages/product-updates.tsx
@@ -8,6 +8,7 @@ import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
 import { serialize } from "next-mdx-remote/serialize";
 import NavbarDev from "../components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "../components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import FooterDev from "../components/FooterDev/FooterDev";
 import { mdxComponents } from "../components/MDXComponents";
 import Image from "next/image";
@@ -314,6 +315,7 @@ const ProductUpdates = ({ versions, versionData }: ProductUpdatesProps) => {
       </Head>
 
       <div className="mx-auto fixed top-0 w-full z-[1030]">
+        <SummitBanner />
         <NavbarDev onClick={() => {}} />
         <NavbarStrip />
       </div>

--- a/src/pages/product-updates.tsx
+++ b/src/pages/product-updates.tsx
@@ -6,9 +6,6 @@ import path from "path";
 import matter from "gray-matter";
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
 import { serialize } from "next-mdx-remote/serialize";
-import NavbarDev from "../components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "../components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import FooterDev from "../components/FooterDev/FooterDev";
 import { mdxComponents } from "../components/MDXComponents";
 import Image from "next/image";
@@ -313,12 +310,6 @@ const ProductUpdates = ({ versions, versionData }: ProductUpdatesProps) => {
           }
         `}</style>
       </Head>
-
-      <div className="mx-auto fixed top-0 w-full z-[1030]">
-        <SummitBanner />
-        <NavbarDev onClick={() => {}} />
-        <NavbarStrip />
-      </div>
 
       <main className="mt-36 bg-white min-h-screen">
         <div className="max-w-[1440px] mx-auto px-4 md:px-10 xl:px-20 py-8 md:py-12">

--- a/src/pages/resources/webinar/carrefour-brasil-spotlight/index.tsx
+++ b/src/pages/resources/webinar/carrefour-brasil-spotlight/index.tsx
@@ -1,11 +1,7 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
 import HubspotForm from "@/components/HubspotForm";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { SPEAKERS } from "@/constants/LandingPage.constants";
 import Image from "next/image";
-import { useRouter } from "next/router";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
   return {
@@ -17,19 +13,8 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const CarrefourPage = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <div>
-      <div className="mx-auto fixed top-0 w-full z-[1030]">
-        <SummitBanner />
-        <NavbarDev onClick={handleTryOpenMetadataClick} />
-        <NavbarStrip />
-      </div>
       <div className="landing-page mt-20 md:mt-24 lg:mt-32">
         <div className="max-w-[1440px] mx-auto py-28 md:py-20 px-4 md:px-10 xl:px-16">
           <div className="grid gap-16 lg:grid-cols-2 xl:grid-cols-3">

--- a/src/pages/resources/webinar/carrefour-brasil-spotlight/index.tsx
+++ b/src/pages/resources/webinar/carrefour-brasil-spotlight/index.tsx
@@ -2,6 +2,7 @@ import FooterDev from "@/components/FooterDev/FooterDev";
 import HubspotForm from "@/components/HubspotForm";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import { SPEAKERS } from "@/constants/LandingPage.constants";
 import Image from "next/image";
 import { useRouter } from "next/router";
@@ -25,6 +26,7 @@ const CarrefourPage = () => {
   return (
     <div>
       <div className="mx-auto fixed top-0 w-full z-[1030]">
+        <SummitBanner />
         <NavbarDev onClick={handleTryOpenMetadataClick} />
         <NavbarStrip />
       </div>

--- a/src/pages/resources/webinar/carrefour-brasil-spotlight/ty-video.tsx
+++ b/src/pages/resources/webinar/carrefour-brasil-spotlight/ty-video.tsx
@@ -1,10 +1,6 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import TyHeader from "@/components/TyVideo/Header";
 import ResourceGallery from "@/components/TyVideo/ResourceGallery";
-import { useRouter } from "next/router";
 import { TY_PAGE_CARREFOUR } from "@/constants/LandingPage.constants";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
@@ -17,19 +13,8 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const CarrefourTy = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <div>
-      <div className="mx-auto fixed top-0 w-full z-[1030]">
-        <SummitBanner />
-        <NavbarDev onClick={handleTryOpenMetadataClick} />
-        <NavbarStrip />
-      </div>
       <div className="landing-page mt-20 md:mt-24 lg:mt-32">
         <div className="max-w-[1440px] mx-auto py-28 md:py-20 px-4 md:px-10 xl:px-16">
           <div className="grid gap-16 lg:grid-cols-2 xl:grid-cols-3">

--- a/src/pages/resources/webinar/carrefour-brasil-spotlight/ty-video.tsx
+++ b/src/pages/resources/webinar/carrefour-brasil-spotlight/ty-video.tsx
@@ -1,6 +1,7 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import TyHeader from "@/components/TyVideo/Header";
 import ResourceGallery from "@/components/TyVideo/ResourceGallery";
 import { useRouter } from "next/router";
@@ -25,6 +26,7 @@ const CarrefourTy = () => {
   return (
     <div>
       <div className="mx-auto fixed top-0 w-full z-[1030]">
+        <SummitBanner />
         <NavbarDev onClick={handleTryOpenMetadataClick} />
         <NavbarStrip />
       </div>

--- a/src/pages/resources/webinar/data-culture/ty-video.tsx
+++ b/src/pages/resources/webinar/data-culture/ty-video.tsx
@@ -1,6 +1,7 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import TyHeader from "@/components/TyVideo/Header";
 import ResourceGallery from "@/components/TyVideo/ResourceGallery";
 import { useRouter } from "next/router";
@@ -25,6 +26,7 @@ const DataCultureTy = () => {
   return (
     <div>
       <div className="mx-auto fixed top-0 w-full z-[1030]">
+        <SummitBanner />
         <NavbarDev onClick={handleTryOpenMetadataClick} />
         <NavbarStrip />
       </div>

--- a/src/pages/resources/webinar/data-culture/ty-video.tsx
+++ b/src/pages/resources/webinar/data-culture/ty-video.tsx
@@ -1,10 +1,6 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import TyHeader from "@/components/TyVideo/Header";
 import ResourceGallery from "@/components/TyVideo/ResourceGallery";
-import { useRouter } from "next/router";
 import { TY_PAGE_DATA_CULTURE } from "@/constants/LandingPage.constants";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
@@ -17,19 +13,8 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const DataCultureTy = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <div>
-      <div className="mx-auto fixed top-0 w-full z-[1030]">
-        <SummitBanner />
-        <NavbarDev onClick={handleTryOpenMetadataClick} />
-        <NavbarStrip />
-      </div>
       <div className="landing-page mt-20 md:mt-24 lg:mt-32">
         <div className="max-w-[1440px] mx-auto py-28 md:py-20 px-4 md:px-10 xl:px-16">
           <div className="grid gap-16 lg:grid-cols-2 xl:grid-cols-3">

--- a/src/pages/resources/webinar/gorgias-spotlight/ty-video.tsx
+++ b/src/pages/resources/webinar/gorgias-spotlight/ty-video.tsx
@@ -1,10 +1,6 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
-import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import TyHeader from "@/components/TyVideo/Header";
 import ResourceGallery from "@/components/TyVideo/ResourceGallery";
-import { useRouter } from "next/router";
 import { TY_PAGE_GORGIAS } from "@/constants/LandingPage.constants";
 
 export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
@@ -17,19 +13,8 @@ export function getServerSideProps({ resolvedUrl }: { resolvedUrl: string }) {
 }
 
 const GorgiasTy = () => {
-  const router = useRouter();
-
-  const handleTryOpenMetadataClick = () => {
-    router.push("/#try-openmetadata");
-  };
-
   return (
     <div>
-      <div className="mx-auto fixed top-0 w-full z-[1030]">
-        <SummitBanner />
-        <NavbarDev onClick={handleTryOpenMetadataClick} />
-        <NavbarStrip />
-      </div>
       <div className="landing-page mt-20 md:mt-24 lg:mt-32">
         <div className="max-w-[1440px] mx-auto py-28 md:py-20 px-4 md:px-10 xl:px-16">
           <div className="grid gap-16 lg:grid-cols-2 xl:grid-cols-3">

--- a/src/pages/resources/webinar/gorgias-spotlight/ty-video.tsx
+++ b/src/pages/resources/webinar/gorgias-spotlight/ty-video.tsx
@@ -1,6 +1,7 @@
 import FooterDev from "@/components/FooterDev/FooterDev";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
 import NavbarStrip from "@/components/NavbarDev/NavbarStrip.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 import TyHeader from "@/components/TyVideo/Header";
 import ResourceGallery from "@/components/TyVideo/ResourceGallery";
 import { useRouter } from "next/router";
@@ -25,6 +26,7 @@ const GorgiasTy = () => {
   return (
     <div>
       <div className="mx-auto fixed top-0 w-full z-[1030]">
+        <SummitBanner />
         <NavbarDev onClick={handleTryOpenMetadataClick} />
         <NavbarStrip />
       </div>


### PR DESCRIPTION
## Summary
- Adds a new `<SummitBanner />` component promoting Collate Summit '26, rendered at the very top of the page (above `<NavbarDev />`)
- Existing `<NavbarStrip />` (Try OpenMetadata signup CTA) is **unchanged** — stays in place as the primary signup funnel
- Banner added to all 25 pages that already use `<NavbarStrip />` (homepage, community, events, mcp, datacontracts, product-updates, cve-list, case-studies + 13 individual case study pages, 3 webinar thank-you pages, case-studies index)

## Copy
> OpenMetadata production stories from OpenAI, Yelp, Rakuten & more — **Register Now for Collate Summit '26** 🚀

The entire phrase "Register Now for Collate Summit '26" is the linked text → https://www.getcollate.io/summit2026 (opens in new tab).

## Changes
- **New file:** `src/components/NavbarDev/SummitBanner.component.tsx` (mirrors `NavbarStrip.component.tsx` pattern, uses `ParamLink`)
- **25 page edits:** import + `<SummitBanner />` inserted above `<NavbarDev />` with matching indentation

## Styling
- Background: `#0B3547` (matches `NavbarStrip` — spacing separates the two strips visually)
- Text: white, 14px, underlined link, emoji

## Test plan
- [ ] Verify banner renders at the very top of homepage, above NavbarDev and NavbarStrip
- [ ] Verify "Register Now for Collate Summit '26" links to https://www.getcollate.io/summit2026 and opens in new tab
- [ ] Mobile + desktop check
- [ ] Spot-check a few other pages (community, mcp, a case-study page)
- [ ] Verify NavbarStrip (Try OpenMetadata signup) still renders and works

## Post-event
Banner will stay post-Summit (June 10, 2026) to link to the recording. To be removed/updated later.