### PR TITLE
Update home page stats: GitHub stars, members, contributors, connectors

### DIFF
--- a/src/components/IntegrationsDev/IntegrationsDev.tsx
+++ b/src/components/IntegrationsDev/IntegrationsDev.tsx
@@ -60,7 +60,7 @@ const IntegrationsDev = () => {
         Integrations
       </h3>
       <p className="text-[#382374] max-w-[80%] mt-2 font-normal text-center mx-auto tracking-[-0.02em] text-[16px] lg:mt-0 lg:text-[#555555] lg:text-[20px] lg:max-w-[54%]">
-        OpenMetadata's ingestion framework supports connectors for 100+ data services, 
+        OpenMetadata's ingestion framework supports connectors for 120+ data services,
         with more added every release.
       </p>
       <div className="mt-[48px] overflow-y-scroll relative shadow-primary rounded-lg md:rounded-2xl sm:flex sm:h-[974px] md:h-[1044px]">

--- a/src/constants/Achievement.constants.tsx
+++ b/src/constants/Achievement.constants.tsx
@@ -8,17 +8,17 @@ export const ACHIEVEMENT_LIST = [
     },
     {
         icon: `${ICON_ROUTE}/open-source-members.svg`,
-        count: '12,000+',
+        count: '13,000+',
         name: 'Open Source Members'
     },
     {
         icon: `${ICON_ROUTE}/code-contributors.svg`,
-        count: '420+',
+        count: '430+',
         name: 'Code Contributors'
     },
     {
         icon: `${ICON_ROUTE}/github-star.svg`,
-        count: '9,000+',
+        count: '11,000+',
         name: 'GitHub Stars'
     },
     {

--- a/src/constants/KeyDataAssets.constants.tsx
+++ b/src/constants/KeyDataAssets.constants.tsx
@@ -18,7 +18,7 @@ export const TABS = [
         "Get the right data to the right people to do their work. OpenMetadata delivers a single source of truth for all your data sources, data pipelines, and data products.",
       imgSrc: "/assets/discovery.webp",
       cases: [
-        "100+ Data Connectors for all your data sources",
+        "120+ Data Connectors for all your data sources",
         "Search, facet, and preview across your data estate",
         "Collaborate with other data practitioners",
       ],

--- a/src/constants/Service.constants.tsx
+++ b/src/constants/Service.constants.tsx
@@ -6,7 +6,7 @@ export const SERVICE_LIST = [
         header3: ' for all your use cases'
     },
     description:
-      "Get complete data context unified across data discovery, observability, and governance, made possible with a Unified Metadata Graph that centralizes all metadata for all data assets. 100+ turnkey connectors make it easy to collect all your metadata and power a unified experience designed to bring data teams together in shared responsibility and contribution.",
+      "Get complete data context unified across data discovery, observability, and governance, made possible with a Unified Metadata Graph that centralizes all metadata for all data assets. 120+ turnkey connectors make it easy to collect all your metadata and power a unified experience designed to bring data teams together in shared responsibility and contribution.",
     icon: "/assets/unified-platform.svg",
   },
   {


### PR DESCRIPTION
## Summary
- GitHub Stars: 9,000+ → 11,000+ (live: 11.2k)
- Open Source Members: 12,000+ → 13,000+
- Code Contributors: 420+ → 430+ (live: 437)
- Connectors: normalize 100+ mentions to 120+ in Why OpenMetadata block, Integrations subhead, and Discovery use-case tab — matches the 120+ already shown in the Achievement section

## Test plan
- [ ] Visual QA on home page: achievement counters, Why OpenMetadata copy, Integrations section, Discovery tab
- [ ] No lint / typecheck regressions