### PR TITLE
Update community meeting video to April 2026

### DIFF
--- a/src/constants/AboutOpenMetadata.constants.tsx
+++ b/src/constants/AboutOpenMetadata.constants.tsx
@@ -36,8 +36,8 @@ export const ABOUT_OPENMETADATA = [
     {
         image: `${IMAGE_ROUTE}/videos-img.webp`,
         header: 'Video',
-        description: 'September Community Meeting',
-        href: 'https://www.youtube.com/watch?v=w1GBD1bU1B8',
+        description: 'April 2026 Community Meeting',
+        href: 'https://www.youtube.com/watch?v=7zJ4iiG8sQo',
         linkText: "Watch",
         isExternal: true
     },


### PR DESCRIPTION
## Summary

Updates the homepage gallery's Video tile (`ABOUT_OPENMETADATA` in `src/constants/AboutOpenMetadata.constants.tsx`) to point at the April 2026 community meeting recording instead of the older September one.

- Description: `September Community Meeting` → `April 2026 Community Meeting`
- URL: `https://www.youtube.com/watch?v=w1GBD1bU1B8` → `https://www.youtube.com/watch?v=7zJ4iiG8sQo`

No image change (still uses the generic `videos-img.webp`).

## Test plan

- [ ] Verify the Video tile in the "Learn More About OpenMetadata" homepage section renders the new title
- [ ] Confirm the link opens the correct April 2026 community meeting on YouTube

🤖 Generated with [Claude Code](https://claude.com/claude-code)