### PR TITLE
chore: add release notes for 1.12.8

### DIFF
--- a/content/product-updates/v1.12.8.md
+++ b/content/product-updates/v1.12.8.md
@@ -1,0 +1,121 @@
+---
+id: 92
+version: v1.12.8
+date: Released on 13th May 2026.
+---
+
+## Changelog
+
+OpenMetadata 1.12.8 is a maintenance release focused on hardening the platform against newly disclosed CVEs, eliminating long-standing database hotspots in the search and tag pipelines, and tightening connector behavior across Databricks, Unity Catalog, Athena, Datalake, and OpenLineage. The release also lands several quality-of-life UI fixes around governance approvals, advanced search, and custom properties.
+
+### ⚠️ Backward Incompatible / Notable Behavior Changes
+
+- **Notification alerts — `Location` source removed** [#27683](https://github.com/open-metadata/OpenMetadata/pull/27683): The deprecated `Location` entity has been removed from the list of supported sources in notification alerts. `Domain` and `Data Product` are now first-class sources. Existing alerts configured against `Location` will need to be re-created against a supported source.
+- **`ContainerResource` default fields trimmed** ([#27894](https://github.com/open-metadata/OpenMetadata/pull/27894) follow-up): `children` is no longer returned by default on `GET /v1/containers` list responses; clients that depended on the implicit inclusion must request it explicitly via the `fields` query parameter. This restores the documented behavior and unblocks the batched data-model column tag retrieval below.
+- **Soft-deleted users excluded from Experts/Reviewers** [#27120](https://github.com/open-metadata/OpenMetadata/pull/27120): Users marked `deleted` no longer appear in the Experts/Reviewers selector across entities. Workflows that relied on soft-deleted users remaining visible (for example, restoring an entity to its previous reviewer) must restore the user first.
+
+### 🔒 Security (Vulnerability Remediation)
+
+This release addresses the May 8 2026 Snyk scan against the 1.12.7 branch and additional CVEs picked up by AWS Inspector. Nine of the highest-severity findings are resolved through direct version bumps; one (`libthrift`) is force-pinned because upstream Jena has not yet rebased.
+
+**Backend / Java**
+
+- **CRITICAL — Jetty HTTP Request Smuggling (CVE-2026-2332):** `org.eclipse.jetty:jetty-http` bumped `12.1.6 → 12.1.7` [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
+- **HIGH — Apache Thrift (CVE-2026-43869):** `libthrift` force-pinned to `0.23.0` via `dependencyManagement` to override the vulnerable transitive shipped by `apache-jena-libs` [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010) / [#28035](https://github.com/open-metadata/OpenMetadata/pull/28035).
+- **HIGH — PostgreSQL JDBC SCRAM-SHA-256 DoS (CVE-2026-42198):** `org.postgresql:postgresql` bumped `42.7.7 → 42.7.11` [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
+- **HIGH — BouncyCastle Crypto Signature Bypass + Timing Attack (CVE-2026-5598):** `bcprov-jdk18on` / `bcpkix-jdk18on` pinned to `1.84`, also addressing CVE-2026-0636 and CVE-2026-5588 [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
+- **HIGH — Apache Log4j (CVE-2026-34477, CVE-2026-34478, CVE-2026-34480):** `log4j` bumped `2.25.3 → 2.25.4` [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994).
+- **MED — Jackson 3.x deserialization CVEs (GHSA-72hv-8253-57qq):** `jackson-core` bumped `2.17.2 → 2.18.7`. `jsonschema2pojo-core` is now declared `<scope>provided</scope>` in the `common` module so the Jackson 3.x transitive is excluded from the runtime classpath, since the annotators it powers only run at build time [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
+- **MED — jsonschema2pojo (CVE-2025-3588):** `jsonschema2pojo` bumped `1.2.2 → 1.3.0` (later aligned to `1.3.1` to resolve a maven-plugin classpath issue) [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994).
+- **MED/LOW — Logback (CVE-2025-11226, CVE-2026-1225):** `logback-core` / `logback-classic` bumped `1.5.19 → 1.5.25` [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
+- **Netty:** `netty-bom` bumped `4.1.132 → 4.1.133`. `netty-transport-native-epoll` excluded (Linux-only perf optimization flagged by an overly-broad GHSA range, not used at runtime) [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994) / [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
+- **Azure Identity (CVE-2024-35255):** `azure-identity` aligned to `1.15.2` and `azure-keyvault` bumped to remove vulnerable transitives [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994) / [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
+- **Reactor Netty & Spring:** `reactor-netty` and `spring` bumped to their current patched lines [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996) / [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
+
+**Frontend / UI**
+
+- **axios** upgraded to `1.15.2` to clear reported CVEs in the UI bundle.
+- **postcss** pinned to `8.5.10` with a Yarn `resolutions` override in `openmetadata-ui-core-components` to resolve the Dependabot advisory [#27778](https://github.com/open-metadata/OpenMetadata/pull/27778).
+- **postcss** bumped in the main UI module as well [#27729](https://github.com/open-metadata/OpenMetadata/pull/27729).
+
+**Ingestion / Container Images**
+
+- **ImageMagick purged** from the ingestion image — it was only a transitive of the Airflow base image, was never used by ingestion code, and continued to surface CVEs after Airflow upgrades. Removing it eliminates the surface entirely [#27752](https://github.com/open-metadata/OpenMetadata/pull/27752).
+
+### 🎨 UI Changes
+
+**Improvements**
+
+- **Approvals show proposed changes inline** [#27201](https://github.com/open-metadata/OpenMetadata/pull/27201): Governance approval task threads now render a *Proposed Changes* section with clickable entity links, so reviewers can see exactly what changed before approving instead of opening the entity in a new tab.
+- **Description added to Advanced Search query builder** [#27913](https://github.com/open-metadata/OpenMetadata/pull/27913): The `description` field is now a first-class searchable attribute with `Contains`, `Not Contains`, `Is Null`, and `Is Not Null` operators. The `descriptionStatus` label was also corrected (previously rendered with the wrong key).
+- **Service documentation panel: admonitions + code copy button** [#27732](https://github.com/open-metadata/OpenMetadata/pull/27732): The in-product service docs now render note/warning/tip admonitions and add a copy button to fenced code blocks.
+
+**Fixes**
+
+- **Clipboard works on non-secure (HTTP) contexts** [#28003](https://github.com/open-metadata/OpenMetadata/pull/28003): `CodeBlockComponent` now uses the `useClipboard` hook, which falls back to `document.execCommand` when the modern Clipboard API is unavailable, fixing copy actions for users on self-hosted HTTP deployments.
+- **Custom properties with dots in their name now display** [#27390](https://github.com/open-metadata/OpenMetadata/pull/27390): The UI was treating `.` in custom-property names as a path separator, hiding the property entirely. Names with dots are now rendered correctly.
+- **Tier/Certification tag matching uses FQN prefix, not substring** [#27700](https://github.com/open-metadata/OpenMetadata/pull/27700): Prevents unrelated tags whose FQN happened to *contain* a tier or certification tag's FQN from being mis-classified.
+- **Upvote/Downvote icon retains primary color after blur** [#27898](https://github.com/open-metadata/OpenMetadata/pull/27898): The vote indicator no longer reverts to a neutral color when the entity page loses focus.
+- **AdvancedSearch description option — translations** [#27961](https://github.com/open-metadata/OpenMetadata/pull/27961): Missing/incorrect i18n strings on the new description operator filled in across supported locales.
+- **Rich-text editor migration** [#26887](https://github.com/open-metadata/OpenMetadata/pull/26887): Removed `@toast-ui/react-editor` and migrated remaining usages to the in-house `BlockEditor`, reducing bundle size and eliminating the transitive CVE surface from the abandoned editor package.
+- **ContainerPage tab counts now update reactively**: Added `childrenCount` to the `useMemo` dependency array so tab badges refresh when children load.
+
+### 🔌 Connectors
+
+**Databases**
+
+- **Databricks — nested column descriptions + SQLAlchemy 2.x** [#27766](https://github.com/open-metadata/OpenMetadata/pull/27766): Descriptions on STRUCT/MAP/ARRAY-typed nested columns are now captured during metadata ingestion. The connector is also compatible with `sqlalchemy-databricks` running on SQLAlchemy 2.x.
+- **Unity Catalog — missing `httpPath`** [#27844](https://github.com/open-metadata/OpenMetadata/pull/27844): The connector no longer hard-fails when `httpPath` is omitted; it now produces a clear configuration error instead of an opaque stack trace.
+- **Athena — Iceberg table properties** [#27715](https://github.com/open-metadata/OpenMetadata/pull/27715): Iceberg-on-Athena tables now ingest table properties from the `$properties` metatable, surfacing Iceberg-specific metadata (format-version, write.target-file-size-bytes, etc.) in OpenMetadata.
+- **PostgreSQL / MSSQL — mutual TLS** [#27104](https://github.com/open-metadata/OpenMetadata/pull/27104): Both connectors now support client-certificate mTLS in addition to server-side SSL, matching enterprise PG/MSSQL hardening requirements.
+- **PostgreSQL — tag_usage seq-scan eliminated** [#27824](https://github.com/open-metadata/OpenMetadata/pull/27824): Backport of #27158. The certification tag query now uses the covering index instead of a sequential scan, removing a multi-second hotspot during Data Insights runs on large catalogs.
+- **SQLAlchemy 2.x row access** [#27643](https://github.com/open-metadata/OpenMetadata/pull/27643): Replaced old-style row indexing that emitted deprecation warnings on SQLAlchemy 2.x.
+
+**Datalake / Object Stores**
+
+- **Datalake — nested arrays of structs in JSON** [#27798](https://github.com/open-metadata/OpenMetadata/pull/27798): Array-typed fields whose elements are nested structures are now parsed correctly and surface as proper nested column schemas.
+
+**Pipelines / Dashboards**
+
+- **Power BI — additional lineage logging** [#27970](https://github.com/open-metadata/OpenMetadata/pull/27970): More granular diagnostic logs in the Power BI lineage extractor make customer-side debugging substantially faster.
+
+**OpenLineage**
+
+- **AWS Glue, Kusto, and Cosmos DB dataset naming** [#27533](https://github.com/open-metadata/OpenMetadata/pull/27533): Adds dataset-naming support so OpenLineage events from these sources are resolved to the correct OpenMetadata entities.
+- **Namespace-based DB service resolution for `db_table`** [#27005](https://github.com/open-metadata/OpenMetadata/pull/27005): OpenLineage `db_table` lookups now resolve to the right DB service by namespace, fixing cross-service lineage gaps.
+- **Pipeline/job resolution by integration type** [#26821](https://github.com/open-metadata/OpenMetadata/pull/26821): OpenLineage pipelines and jobs are now mapped to their integration type so they show up under the correct pipeline service.
+
+**AI / Vector Embeddings**
+
+- **OpenAI embedding concurrency control** [#26574](https://github.com/open-metadata/OpenMetadata/pull/26574): Adds a configurable concurrency cap on outbound OpenAI embedding HTTP requests, preventing rate-limit storms during bulk reindex.
+
+**Ingestion Runtime**
+
+- **Bulk sink OOM under persistent flush failures** [#26838](https://github.com/open-metadata/OpenMetadata/pull/26838): The bulk sink no longer accumulates an unbounded retry buffer when downstream flushes keep failing; the buffer is now bounded and drops with a clear error.
+- **CronOMJob tolerations propagated** [#27955](https://github.com/open-metadata/OpenMetadata/pull/27955): Pod tolerations defined on a `CronOMJob` are now copied to the scheduled `OMJob`, so taint-isolated nodes keep working after a restart.
+- **PII recognizer language scoping** [#27919](https://github.com/open-metadata/OpenMetadata/pull/27919): PII recognizers are now included based on the configured language, eliminating false positives from recognizers loaded for unrelated locales.
+- **`dbt-extractor` pinned `>=0.5.0`** [#27777](https://github.com/open-metadata/OpenMetadata/pull/27777): Prevents the ARM-on-pip resolver from falling back to a source distribution that fails to build inside the ingestion container.
+
+### 🛠 API (Backend)
+
+**Improvements**
+
+- **Reindex memory optimization for DatabaseSchema** [#27723](https://github.com/open-metadata/OpenMetadata/pull/27723) / [#28061](https://github.com/open-metadata/OpenMetadata/pull/28061): `DatabaseSchemaIndex` now skips the `tables` fan-out during reindex, reducing memory pressure on catalogs with very large schemas. All other entity indexes hydrate the full field set as before.
+- **SearchUtils consolidated; fuzzy ngram removed** [#27636](https://github.com/open-metadata/OpenMetadata/pull/27636): Merged the duplicated SearchUtils classes into one and dropped the redundant fuzzy match on ngram-tokenized fields (fuzzy + ngram compounded false positives). Adds substantial unit-test coverage.
+- **Certification tag batch query — source filter + indexed hash prefix** [#27847](https://github.com/open-metadata/OpenMetadata/pull/27847): The `TagUsageDAO.getCertTagsInternalBatch` query previously did a `tagFQN LIKE 'Certification.%'` scan and ran ~12s per call on heavy classification hierarchies. With a `source` filter and a hash-prefix predicate it now uses the covering index — eliminating ~19 hours of cumulative DB time per Data Insights run on a representative customer instance.
+- **Container data-model column tags — batched** [#27894](https://github.com/open-metadata/OpenMetadata/pull/27894): Replaces per-column tag lookups with a single batched query.
+- **`IndexResource` logs lowered to debug** [#27588](https://github.com/open-metadata/OpenMetadata/pull/27588): Reduces production log noise; verbose index lifecycle logs are now gated on `DEBUG`.
+
+**Fixes**
+
+- **`DataContract` 400 on entities without `dataProducts`** [#27861](https://github.com/open-metadata/OpenMetadata/pull/27861): The endpoint now handles entities that don't carry a `dataProducts` field, instead of rejecting the request.
+- **`/search` endpoint for Roles** [#27335](https://github.com/open-metadata/OpenMetadata/pull/27335): Adds the missing `GET /v1/roles/search` endpoint and aligns role selectors to use server-side search [#27737](https://github.com/open-metadata/OpenMetadata/pull/27737).
+- **MCP — SSE response when client negotiates `text/event-stream`** [#27917](https://github.com/open-metadata/OpenMetadata/pull/27917): The MCP endpoint now correctly returns an SSE-framed response when the client's `Accept` header asks for `text/event-stream`.
+- **MCP OAuth on Databricks** [#27922](https://github.com/open-metadata/OpenMetadata/pull/27922): Fixes the OAuth callback handling specific to Databricks-backed MCP clients.
+- **Time-series reindex — stale `parentOf` is a warning, not a failure** [#27800](https://github.com/open-metadata/OpenMetadata/pull/27800): During time-series reindex, an orphaned `parentOf` reference no longer aborts the run; it's logged as a warning and the reindex continues.
+- **Column bulk-ops search at scale** [#27216](https://github.com/open-metadata/OpenMetadata/pull/27216): Bulk operations on columns now return results consistently on large indices where the previous code path silently returned an empty set above a query-size threshold.
+- **OpenSearch HC5 transport — recoverable I/O reactor shutdown** [#27698](https://github.com/open-metadata/OpenMetadata/pull/27698): Transient `I/O reactor has been shut down` errors are now recovered automatically instead of leaving the client in a permanently failed state.
+- **Vector embedding healthcheck** [#27616](https://github.com/open-metadata/OpenMetadata/pull/27616): The `/health` probe now correctly reflects vector-embedding subsystem availability instead of always reporting healthy.
+- **CSV import — recursive extension validation + row-count accounting** [#27593](https://github.com/open-metadata/OpenMetadata/pull/27593) / [#27669](https://github.com/open-metadata/OpenMetadata/pull/27669): Recursive imports now validate `entityType` per row correctly and the post-import row counts match the file.
+- **`TableColumnCountToBeBetween` API response** [#27900](https://github.com/open-metadata/OpenMetadata/pull/27900): The Data Quality endpoint now returns the expected response shape for this test.
+- **Hyperlink workflow rules — `.keyword` suffix + Tags/Tier disambiguation** [#27799](https://github.com/open-metadata/OpenMetadata/pull/27799): Workflow rule conditions referencing tags/tier no longer match on the analyzed text field; they bind to `.keyword` so prefix collisions between Tags and Tier are resolved.

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "v1.12.8",
+    "date": "Released on 13th May 2026.",
+    "hasFeatures": false
+  },
+  {
     "version": "v1.12.7",
     "date": "Released on 12th May 2026.",
     "hasFeatures": false


### PR DESCRIPTION
## Summary
- Add release notes for OpenMetadata 1.12.8 (released 13th May 2026)
- Carries forward 1.12.7 content as the baseline; reindex improvement bullet rewritten to reflect 1.12.8's final scope (DatabaseSchema-only opt-out for the `tables` fan-out)
- Mirrors the GitHub 1.12.8 release: https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.8-release

## Test plan
- [ ] `npm run dev` → `/product-updates` shows 1.12.8 at the top of the version list
- [ ] `/product-updates/v1.12.8` renders the new page