### PR TITLE
Add markdown files for all pages with page content

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,22 @@ const nextConfig = {
     dangerouslyAllowSVG: true,
     unoptimized: true,
   },
+  async rewrites() {
+    return [
+      {
+        source: "/index.md",
+        destination: "/api/md",
+      },
+      {
+        source: "/:slug.md",
+        destination: "/api/md/:slug",
+      },
+      {
+        source: "/:a/:slug.md",
+        destination: "/api/md/:a/:slug",
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/react-dom": "^18.3.5",
         "aos": "^2.3.4",
         "autoprefixer": "10.4.18",
+        "cheerio": "^1.2.0",
         "eslint": "8.57.0",
         "eslint-config-next": "^14.2.35",
         "gray-matter": "^4.0.3",
@@ -31,11 +32,13 @@
         "slick-carousel": "^1.8.1",
         "strip-markdown": "^6.0.0",
         "tailwindcss": "3.4.1",
+        "turndown": "^7.2.4",
         "typescript": "5.3.3"
       },
       "devDependencies": {
         "@types/aos": "^3.0.7",
-        "@types/react-slick": "^0.23.13"
+        "@types/react-slick": "^0.23.13",
+        "@types/turndown": "^5.0.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -341,6 +344,12 @@
         "@types/react": ">=16",
         "react": ">=16"
       }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@next/env": {
       "version": "14.2.35",
@@ -661,6 +670,13 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1302,6 +1318,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1477,6 +1499,48 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1584,6 +1648,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -1715,6 +1807,61 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1729,6 +1876,19 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.15.1",
@@ -1746,6 +1906,18 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
       "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.22.5",
@@ -2992,6 +3164,49 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -4635,6 +4850,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4838,6 +5065,55 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -5529,6 +5805,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -6142,6 +6424,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6257,6 +6552,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -6497,6 +6801,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/react-dom": "^18.3.5",
     "aos": "^2.3.4",
     "autoprefixer": "10.4.18",
+    "cheerio": "^1.2.0",
     "eslint": "8.57.0",
     "eslint-config-next": "^14.2.35",
     "gray-matter": "^4.0.3",
@@ -33,10 +34,12 @@
     "slick-carousel": "^1.8.1",
     "strip-markdown": "^6.0.0",
     "tailwindcss": "3.4.1",
+    "turndown": "^7.2.4",
     "typescript": "5.3.3"
   },
   "devDependencies": {
     "@types/aos": "^3.0.7",
-    "@types/react-slick": "^0.23.13"
+    "@types/react-slick": "^0.23.13",
+    "@types/turndown": "^5.0.6"
   }
 }

--- a/src/components/NavbarDev/NavbarStrip.component.tsx
+++ b/src/components/NavbarDev/NavbarStrip.component.tsx
@@ -3,7 +3,7 @@ import ParamLink from "../ParamLink";
 
 const NavbarStrip = () => {
   return (
-    <div data-nomd className="bg-[#F2F2F2] mx-auto text-[#181D27] py-[12px] px-8 md:text-center lg:py-[8px] lg:px-12">
+    <div className="nav-strip bg-[#F2F2F2] mx-auto text-[#181D27] py-[12px] px-8 md:text-center lg:py-[8px] lg:px-12">
       <div className="custom-container flex justify-center items-center gap-3">
         <CollateLogo />
         <div className="max-w-[80%] lg:flex lg:gap-3 lg:items-center">

--- a/src/components/NavbarDev/NavbarStrip.component.tsx
+++ b/src/components/NavbarDev/NavbarStrip.component.tsx
@@ -3,7 +3,7 @@ import ParamLink from "../ParamLink";
 
 const NavbarStrip = () => {
   return (
-    <div className="bg-[#F2F2F2] mx-auto text-[#181D27] py-[12px] px-8 md:text-center lg:py-[8px] lg:px-12">
+    <div data-nomd className="bg-[#F2F2F2] mx-auto text-[#181D27] py-[12px] px-8 md:text-center lg:py-[8px] lg:px-12">
       <div className="custom-container flex justify-center items-center gap-3">
         <CollateLogo />
         <div className="max-w-[80%] lg:flex lg:gap-3 lg:items-center">

--- a/src/components/NavbarDev/SummitBanner.component.tsx
+++ b/src/components/NavbarDev/SummitBanner.component.tsx
@@ -2,7 +2,7 @@ import ParamLink from "../ParamLink";
 
 const SummitBanner = () => {
   return (
-    <div className="w-full py-[6px] px-5 text-center" style={{ background: "linear-gradient(270deg, #ECE5FF 39.9%, #7147E8 114.41%)" }}>
+    <div data-nomd className="w-full py-[6px] px-5 text-center" style={{ background: "linear-gradient(270deg, #ECE5FF 39.9%, #7147E8 114.41%)" }}>
       <span className="text-black text-sm">
         OpenMetadata production stories from OpenAI, Yelp, Rakuten &amp; more —{" "}
         <ParamLink

--- a/src/components/NavbarDev/SummitBanner.component.tsx
+++ b/src/components/NavbarDev/SummitBanner.component.tsx
@@ -2,7 +2,7 @@ import ParamLink from "../ParamLink";
 
 const SummitBanner = () => {
   return (
-    <div data-nomd className="w-full py-[6px] px-5 text-center" style={{ background: "linear-gradient(270deg, #ECE5FF 39.9%, #7147E8 114.41%)" }}>
+    <div className="w-full py-[6px] px-5 text-center summit-bg">
       <span className="text-black text-sm">
         OpenMetadata production stories from OpenAI, Yelp, Rakuten &amp; more —{" "}
         <ParamLink

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -28,6 +28,10 @@ export default function App({ Component, pageProps }: AppProps) {
   };
 
   const canonicalUrl = pageProps.link?.split("?")[0]
+  const markdownUrl =
+    !canonicalUrl || canonicalUrl === "/"
+      ? "https://open-metadata.org/index.md"
+      : `https://open-metadata.org${canonicalUrl.replace(/\/$/, "")}.md`
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -66,6 +70,9 @@ export default function App({ Component, pageProps }: AppProps) {
           rel="canonical"
           href={`https://open-metadata.org${canonicalUrl}`}
         />
+        {markdownUrl && (
+          <link rel="alternate" type="text/markdown" href={markdownUrl} />
+        )}
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, shrink-to-fit=no"

--- a/src/pages/api/md/[[...slug]].ts
+++ b/src/pages/api/md/[[...slug]].ts
@@ -75,7 +75,8 @@ export default async function handler(
         ".announcement-banner",
         ".table-of-contents",
         ".toc",
-        "[data-nomd]",
+        ".summit-bg",
+        ".nav-strip",
       ].join(",")
     ).remove();
 

--- a/src/pages/api/md/[[...slug]].ts
+++ b/src/pages/api/md/[[...slug]].ts
@@ -1,0 +1,133 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import * as cheerio from "cheerio";
+import TurndownService from "turndown";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const rawSlug = (req.query.slug as string[] | undefined) ?? [];
+
+  const cleanSlug = rawSlug.map((s) =>
+    s.endsWith(".md") ? s.slice(0, -3) : s
+  );
+
+  const isIndex =
+    cleanSlug.length === 1 && cleanSlug[0] === "index";
+
+  const path =
+    cleanSlug.length === 0 || isIndex
+      ? "/"
+      : `/${cleanSlug.join("/")}`;
+
+  const protocol =
+    (req.headers["x-forwarded-proto"] as string) || "http";
+
+  const host = (req.headers.host as string) || "open-metadata.org";
+
+  const siteUrl = host.startsWith("http")
+    ? host
+    : `${protocol}://${host}`;
+
+  const fetchUrl = `${siteUrl}${path}`;
+
+  try {
+    const response = await fetch(fetchUrl);
+
+    if (!response.ok) {
+      res
+        .status(404)
+        .setHeader("Content-Type", "text/plain; charset=utf-8")
+        .send("Page not found");
+      return;
+    }
+
+    const html = await response.text();
+
+    if (!html) {
+      res
+        .status(500)
+        .setHeader("Content-Type", "text/plain; charset=utf-8")
+        .send("Empty HTML response");
+      return;
+    }
+
+    const $ = cheerio.load(html);
+
+    $(
+      [
+        "nav",
+        "footer",
+        "aside",
+        "script",
+        "style",
+        "noscript",
+        "iframe",
+      ].join(",")
+    ).remove();
+
+    $(
+      [
+        ".sidebar",
+        ".navbar",
+        ".footer",
+        ".cookie-modal",
+        ".announcement-banner",
+        ".table-of-contents",
+        ".toc",
+        "[data-nomd]",
+      ].join(",")
+    ).remove();
+
+    // Remove YouTube article elements before selecting content
+    // (react-lite-youtube-embed renders <article class="yt-lite"> which would
+    //  match $("article") and return only the play button — empty markdown)
+    $("article.yt-lite").remove();
+
+    const content = $("body").html();
+
+    if (!content) {
+      res
+        .status(500)
+        .setHeader("Content-Type", "text/plain; charset=utf-8")
+        .send("No content found");
+      return;
+    }
+
+    const turndownService = new TurndownService({
+      headingStyle: "atx",
+      codeBlockStyle: "fenced",
+      bulletListMarker: "-",
+    });
+
+    turndownService.addRule("pre", {
+      filter: ["pre"],
+      replacement: function (content) {
+        return `\n\`\`\`\n${content}\n\`\`\`\n`;
+      },
+    });
+
+    turndownService.addRule("links", {
+      filter: "a",
+      replacement: function (content, node) {
+        const href = (node as HTMLAnchorElement).getAttribute("href");
+        if (!href) return content;
+        return `[${content}](${href})`;
+      },
+    });
+
+    const markdown = turndownService.turndown(content);
+
+    res
+      .status(200)
+      .setHeader("Content-Type", "text/markdown; charset=utf-8")
+      .setHeader("X-Robots-Tag", "index, follow")
+      .send(markdown);
+  } catch (error) {
+    console.error("Markdown generation error:", error);
+    res
+      .status(500)
+      .setHeader("Content-Type", "text/plain; charset=utf-8")
+      .send("Error generating markdown");
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -53,6 +53,10 @@ p{
   @apply bg-gradient-to-b from-[#F1EDFD] to-white
 }
 
+.summit-bg {
+  background: linear-gradient(270deg, #ECE5FF 39.9%, #7147E8 114.41%);
+}
+
 .nav-strip-btn {
   border: none;
   text-decoration: underline;


### PR DESCRIPTION
Added an automated system that generates a clean Markdown version for every HTML page on the site.

This is because AI crawlers and LLM training systems (ChatGPT, Perplexity, ClaudeBot, Google AI Overviews) parse Markdown more efficiently than HTML. Currently the site serves only HTML — there are no corresponding .md versions of pages available. Having a Markdown version of each page accessible at the same URL with a .md extension improves content accessibility for AI engines and aligns with emerging GEO best practices.