### PR TITLE
Stats bump: 14,000+ GitHub stars, 130+ connectors

### DIFF
--- a/src/components/IntegrationsDev/IntegrationsDev.tsx
+++ b/src/components/IntegrationsDev/IntegrationsDev.tsx
@@ -60,7 +60,7 @@ const IntegrationsDev = () => {
         Integrations
       </h3>
       <p className="text-[#382374] max-w-[80%] mt-2 font-normal text-center mx-auto tracking-[-0.02em] text-[16px] lg:mt-0 lg:text-[#555555] lg:text-[20px] lg:max-w-[54%]">
-        OpenMetadata's ingestion framework supports connectors for 120+ data services,
+        OpenMetadata's ingestion framework supports connectors for 130+ data services,
         with more added every release.
       </p>
       <div className="mt-[48px] overflow-y-scroll relative shadow-primary rounded-lg md:rounded-2xl sm:flex sm:h-[1050px] md:h-[1124px]">

--- a/src/constants/Achievement.constants.tsx
+++ b/src/constants/Achievement.constants.tsx
@@ -18,7 +18,7 @@ export const ACHIEVEMENT_LIST = [
     },
     {
         icon: `${ICON_ROUTE}/github-star.svg`,
-        count: '11,000+',
+        count: '14,000+',
         name: 'GitHub Stars'
     },
     {
@@ -28,7 +28,7 @@ export const ACHIEVEMENT_LIST = [
     },
     {
         icon: `${ICON_ROUTE}/data-connector.svg`,
-        count: '120+',
+        count: '130+',
         name: 'Data Connectors'
     },
 ]

--- a/src/constants/KeyDataAssets.constants.tsx
+++ b/src/constants/KeyDataAssets.constants.tsx
@@ -18,7 +18,7 @@ export const TABS = [
         "Get the right data to the right people to do their work. OpenMetadata delivers a single source of truth for all your data sources, data pipelines, and data products.",
       imgSrc: "/assets/discovery.webp",
       cases: [
-        "120+ Data Connectors for all your data sources",
+        "130+ Data Connectors for all your data sources",
         "Search, facet, and preview across your data estate",
         "Collaborate with other data practitioners",
       ],

--- a/src/constants/Service.constants.tsx
+++ b/src/constants/Service.constants.tsx
@@ -6,7 +6,7 @@ export const SERVICE_LIST = [
         header3: ' for all your use cases'
     },
     description:
-      "Get complete data context unified across data discovery, observability, and governance, made possible with a Unified Metadata Graph that centralizes all metadata for all data assets. 120+ turnkey connectors make it easy to collect all your metadata and power a unified experience designed to bring data teams together in shared responsibility and contribution.",
+      "Get complete data context unified across data discovery, observability, and governance, made possible with a Unified Metadata Graph that centralizes all metadata for all data assets. 130+ turnkey connectors make it easy to collect all your metadata and power a unified experience designed to bring data teams together in shared responsibility and contribution.",
     icon: "/assets/unified-platform.svg",
   },
   {


### PR DESCRIPTION
## Summary
Hot stat update for live home page:
- GitHub Stars: 11,000+ → **14,000+**
- Data Connectors: 120+ → **130+** (across Achievement section, Why OpenMetadata block 1, Integrations subhead, Discovery use-case tab)

## Test plan
- [ ] Netlify preview shows updated counters
- [ ] No lint/typecheck regressions