### PR TITLE
fix: correct PR numbers in v1.12.9 changelog

### DIFF
--- a/content/product-updates/v1.12.9.md
+++ b/content/product-updates/v1.12.9.md
@@ -12,8 +12,8 @@ OpenMetadata 1.12.9 is a maintenance release delivering new connector capabiliti
 
 - **Unity Catalog — incremental metadata extraction** [#28380](https://github.com/open-metadata/OpenMetadata/pull/28380): Unity Catalog connector now detects changed tables via `information_schema.tables.last_altered` and only re-ingests modified entities. Delete detection uses exact catalog matching (preventing wildcard misfires on catalog names containing underscores). Catalog names are validated against an allowlist before SQL interpolation.
 - **Task domains backfilled + stamped on approval** [#28402](https://github.com/open-metadata/OpenMetadata/pull/28402): Approval task threads now inherit the domain of the entity being approved, and a migration backfills domains on existing tasks.
-- **Workflow entity extended fields** [#28398](https://github.com/open-metadata/OpenMetadata/pull/28398): `Workflow` entities now support `inputPorts`, `outputPorts`, and `glossaryTerms` fields, bringing them to parity with pipeline and data-flow entities.
-- **MySQL — custom `queryHistoryTable`** [#28388](https://github.com/open-metadata/OpenMetadata/pull/28388): MySQL connector accepts a configurable `queryHistoryTable` for usage and lineage extraction, enabling use-cases where query history is stored in a non-default location.
+- **Workflow entity extended fields** [#28120](https://github.com/open-metadata/OpenMetadata/pull/28120): `Workflow` entities now support `inputPorts`, `outputPorts`, and `glossaryTerms` fields, bringing them to parity with pipeline and data-flow entities.
+- **MySQL — custom `queryHistoryTable`** [#28260](https://github.com/open-metadata/OpenMetadata/pull/28260): MySQL connector accepts a configurable `queryHistoryTable` for usage and lineage extraction, enabling use-cases where query history is stored in a non-default location.
 
 ### 🔒 Security
 
@@ -53,7 +53,7 @@ OpenMetadata 1.12.9 is a maintenance release delivering new connector capabiliti
 
 - **Bulk sink — charts and dataModels created before dashboards** [#28371](https://github.com/open-metadata/OpenMetadata/pull/28371): Fixed a bulk sink ordering bug where a Dashboard entity could be flushed before its referenced Charts or DashboardDataModels, causing HTTP 400 rejections from the server. Each topology stage now encodes its position so referenced entities are always created first.
 - **Power BI — sink buffer flushed before lineage resolution** [#28308](https://github.com/open-metadata/OpenMetadata/pull/28308): Ensures all Power BI entities are persisted before lineage resolution begins, preventing reference errors during lineage extraction.
-- **Power BI — TSQL dialect for `Sql.Database` M-query lineage** [#28380](https://github.com/open-metadata/OpenMetadata/pull/28380): The Power BI connector now parses `Sql.Database` M-query expressions using the TSQL dialect, fixing lineage extraction failures on SQL Server-backed datasets.
+- **Power BI — TSQL dialect for `Sql.Database` M-query lineage** [#28250](https://github.com/open-metadata/OpenMetadata/pull/28250): The Power BI connector now parses `Sql.Database` M-query expressions using the TSQL dialect, fixing lineage extraction failures on SQL Server-backed datasets.
 
 **OpenLineage**
 


### PR DESCRIPTION
## Summary

Fixes 3 incorrect PR numbers in `content/product-updates/v1.12.9.md`:

| Entry | Was | Correct |
|-------|-----|---------|
| MySQL `queryHistoryTable` | #28388 (not found) | #28260 |
| Power BI TSQL dialect M-query lineage | #28380 (Unity Catalog PR) | #28250 |
| Workflow `inputPorts`/`outputPorts`/`glossaryTerms` | #28398 (search-index refactor) | #28120 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)