### PR TITLE
chore(release): Add changelog for OpenMetadata v1.12.10 release

### DIFF
--- a/content/product-updates/v1.12.10.md
+++ b/content/product-updates/v1.12.10.md
@@ -44,11 +44,8 @@ OpenMetadata 1.12.10 is a maintenance release delivering critical security patch
 ### 🎨 UI & UX Fixes
 
 - **Fix entity type filter update button click** [#28573](https://github.com/open-metadata/OpenMetadata/pull/28573): Corrected entity type filter interaction where update button click was not being registered.
-- **Fix Teams drag-and-drop Playwright timeout** [#28607](https://github.com/open-metadata/OpenMetadata/pull/28607): Resolved Teams component drag-and-drop interaction timeouts in UI tests.
 - **Translation fixes for ru-ru and ko-kr locales** [#28584](https://github.com/open-metadata/OpenMetadata/pull/28584): Corrected translation values for Russian and Korean language packs.
-- **Fix flaky toast assertion in tests** [#28566](https://github.com/open-metadata/OpenMetadata/pull/28566): Improved test reliability for toast notification assertions.
 - **Test suite pre-select every test case already in suite** [#28400](https://github.com/open-metadata/OpenMetadata/pull/28400): Fixed test case selection logic to pre-select all test cases already added to a suite.
-- **Fix Playwright data mismatch from migration testing** [#28496](https://github.com/open-metadata/OpenMetadata/pull/28496): Corrected Playwright test data mismatches introduced by migration testing.
 
 ### 🐛 General Bug Fixes
 

--- a/content/product-updates/v1.12.10.md
+++ b/content/product-updates/v1.12.10.md
@@ -1,7 +1,7 @@
 ---
 id: 95
 version: v1.12.10
-date: Released on 2nd June 2026.
+date: Released on 3nd June 2026.
 ---
 
 ## Changelog

--- a/content/product-updates/v1.12.10.md
+++ b/content/product-updates/v1.12.10.md
@@ -1,0 +1,61 @@
+---
+id: 95
+version: v1.12.10
+date: Released on 2nd June 2026.
+---
+
+## Changelog
+
+OpenMetadata 1.12.10 is a maintenance release delivering critical security patches, MCP enhancements, and targeted bug fixes across migrations, search, UI, and ingestion runtime.
+
+### 🔒 Security
+
+- **Snyk high/critical dependency patches in ingestion** [#28623](https://github.com/open-metadata/OpenMetadata/pull/28623): High and critical Snyk findings patched across ingestion dependencies to address multiple CVEs.
+- **Jackson-core and CloudFront Snyk high patches** [#28614](https://github.com/open-metadata/OpenMetadata/pull/28614): Resolved Snyk high-severity vulnerabilities in jackson-core 3.0.2 and cloudfront 2.30.19.
+- **Axios version bump for Retire.js vulnerabilities** [#28582](https://github.com/open-metadata/OpenMetadata/pull/28582): Frontend dependency updated to address reported Retire.js vulnerabilities.
+- **XSS security fix with explicit jsonify** [#28574](https://github.com/open-metadata/OpenMetadata/pull/28574): Made jsonify explicit at route level to break XSS taint chains.
+- **CVE fixes in ingestion images** [#28534](https://github.com/open-metadata/OpenMetadata/pull/28534): Closed gnutls, libcap, openssh, and rsync CVEs in ingestion container images.
+- **mlflow-skinny and jsonify security bumps** [#28501](https://github.com/open-metadata/OpenMetadata/pull/28501): Updated mlflow-skinny and surface jsonify in trigger route for security.
+- **Presidio utils XSS false positives fix** [#28535](https://github.com/open-metadata/OpenMetadata/pull/28535): Dropped **kwargs Any from presidio_utils factories to clear XSS false positives.
+
+### 🔌 MCP (Model Context Protocol) Enhancements
+
+- **MCP tool error responses mapped to correct HTTP status codes** [#28644](https://github.com/open-metadata/OpenMetadata/pull/28644): Tool errors now properly map to their corresponding HTTP status codes.
+- **New MCP tools added** [#28586](https://github.com/open-metadata/OpenMetadata/pull/28586): Extended MCP tool capabilities with new tools for enhanced functionality.
+- **Optimize get_entity_lineage MCP tool payload** [#28618](https://github.com/open-metadata/OpenMetadata/pull/28618): Reduced payload size of get_entity_lineage tool with slim transform optimization.
+- **MCP custom properties in get_entity_details** [#28570](https://github.com/open-metadata/OpenMetadata/pull/28570): Surface custom extension properties in get_entity_details tool responses.
+- **MCP SAML SSO support in OAuth flow** [#28548](https://github.com/open-metadata/OpenMetadata/pull/28548): Added SAML SSO support for MCP OAuth authentication flow.
+- **MCP client secret handling for public clients** [#28552](https://github.com/open-metadata/OpenMetadata/pull/28552): Fixed to not issue client secret to public clients.
+- **MCP prefer application/json over SSE** [#28558](https://github.com/open-metadata/OpenMetadata/pull/28558): MCP now prefers application/json response format when client accepts both JSON and SSE.
+- **MCP Tool Usage improvements** [#28352](https://github.com/open-metadata/OpenMetadata/pull/28352): Enhanced MCP tool usage tracking and execution capabilities.
+
+### 🛠 API & Migration Fixes
+
+- **Migration heal stuck PG certification** [#28635](https://github.com/open-metadata/OpenMetadata/pull/28635): Fixed migration to heal stuck PostgreSQL certification records stranded by v1125 update.
+- **Migration cast :metadata to json on PG tag_usage** [#28504](https://github.com/open-metadata/OpenMetadata/pull/28504): Corrected metadata field casting in PostgreSQL tag_usage insert statements.
+
+### 🔍 Search & Indexing Fixes
+
+- **Fix search by nested field names for topics and API endpoints** [#28610](https://github.com/open-metadata/OpenMetadata/pull/28610): Resolved issue where nested field name searches failed for topics and API endpoints.
+- **Scrub stale file extension aggregation on upgrade** [#28565](https://github.com/open-metadata/OpenMetadata/pull/28565): Prevented file search 500 errors by cleaning up stale file extension aggregation data during upgrade.
+- **Backport immense-term children mapping fix** [#28572](https://github.com/open-metadata/OpenMetadata/pull/28572): Applied fix for deeply nested children fields that were causing search mapping issues.
+- **Stop orphan test cases from breaking search indexing** [#28159](https://github.com/open-metadata/OpenMetadata/pull/28159): Prevented orphaned test cases from causing search index failures.
+
+### 🎨 UI & UX Fixes
+
+- **Fix entity type filter update button click** [#28573](https://github.com/open-metadata/OpenMetadata/pull/28573): Corrected entity type filter interaction where update button click was not being registered.
+- **Fix Teams drag-and-drop Playwright timeout** [#28607](https://github.com/open-metadata/OpenMetadata/pull/28607): Resolved Teams component drag-and-drop interaction timeouts in UI tests.
+- **Translation fixes for ru-ru and ko-kr locales** [#28584](https://github.com/open-metadata/OpenMetadata/pull/28584): Corrected translation values for Russian and Korean language packs.
+- **Fix flaky toast assertion in tests** [#28566](https://github.com/open-metadata/OpenMetadata/pull/28566): Improved test reliability for toast notification assertions.
+- **Test suite pre-select every test case already in suite** [#28400](https://github.com/open-metadata/OpenMetadata/pull/28400): Fixed test case selection logic to pre-select all test cases already added to a suite.
+- **Fix Playwright data mismatch from migration testing** [#28496](https://github.com/open-metadata/OpenMetadata/pull/28496): Corrected Playwright test data mismatches introduced by migration testing.
+
+### 🐛 General Bug Fixes
+
+- **Fixed classification visit method** [#28636](https://github.com/open-metadata/OpenMetadata/pull/28636): Corrected the visit method for classification entity traversal.
+- **Fix flaky domain & data product rename** [#28580](https://github.com/open-metadata/OpenMetadata/pull/28580): Improved stability of domain and data product rename operations by handling search version conflicts.
+- **Fix fasturi dependency** [#28139](https://github.com/open-metadata/OpenMetadata/pull/28139): Updated fasturi dependency to resolve compatibility issues.
+
+### 📦 Dependencies & Infrastructure
+
+- **Kubernetes client pinned below 36.0.0** (from v1.12.9): Maintained compatibility by capping Kubernetes Python client to avoid breaking API changes.

--- a/content/product-updates/v1.12.10.md
+++ b/content/product-updates/v1.12.10.md
@@ -1,7 +1,7 @@
 ---
 id: 95
 version: v1.12.10
-date: Released on 3nd June 2026.
+date: Released on 3rd June 2026.
 ---
 
 ## Changelog

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,7 +1,7 @@
 [
   {
     "version": "v1.12.10",
-    "date": "Released on 2nd June 2026.",
+    "date": "Released on 3nd June 2026.",
     "hasFeatures": false
   },
   {

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "v1.12.10",
+    "date": "Released on 2nd June 2026.",
+    "hasFeatures": false
+  },
+  {
     "version": "v1.12.9",
     "date": "Released on 28th May 2026.",
     "hasFeatures": false

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,7 +1,7 @@
 [
   {
     "version": "v1.12.10",
-    "date": "Released on 3nd June 2026.",
+    "date": "Released on 3rd June 2026.",
     "hasFeatures": false
   },
   {


### PR DESCRIPTION
Add changelog for OpenMetadata v1.12.10 release (3nd June 2026) covering:
- MCP tool error response mapping
- Security patches (Snyk high/critical, XSS fixes, CVE closures)
- Migration fixes for PostgreSQL certification and tag_usage
- Search and indexing improvements
- UI and UX bug fixes
- Translation fixes
- General bug fixes

Also prepend v1.12.10 entry to versions.json.