### PR TITLE
chore(achievements): refresh community metrics post-Summit

### DIFF
--- a/src/constants/Achievement.constants.tsx
+++ b/src/constants/Achievement.constants.tsx
@@ -3,17 +3,17 @@ const ICON_ROUTE = '/assets/achievement'
 export const ACHIEVEMENT_LIST = [
     {
         icon: `${ICON_ROUTE}/deployment.svg`,
-        count: '3,000+',
+        count: '4,000+',
         name: 'Enterprise Deployments'
     },
     {
         icon: `${ICON_ROUTE}/open-source-members.svg`,
-        count: '13,000+',
+        count: '13,500+',
         name: 'Open Source Members'
     },
     {
         icon: `${ICON_ROUTE}/code-contributors.svg`,
-        count: '430+',
+        count: '450+',
         name: 'Code Contributors'
     },
     {


### PR DESCRIPTION
## Summary

Refresh community metrics in `ACHIEVEMENT_LIST` to match the numbers shared in the OpenMetadata community update at Collate Summit '26.

- Enterprise Deployments: **3,000+ → 4,000+**
- Open Source Members: **13,000+ → 13,500+**
- Code Contributors: **430+ → 450+**

GitHub Stars (14,000+), Data Connectors (130+), and Data Assets (2+ Million) unchanged.

## Test plan

- [ ] Verify the Achievement section renders new counts on open-metadata.org after deploy