### PR TITLE
feat(product-updates): add v1.12.11 release notes

### DIFF
--- a/content/product-updates/v1.12.11.md
+++ b/content/product-updates/v1.12.11.md
@@ -1,0 +1,73 @@
+---
+id: 96
+version: v1.12.11
+date: Released on 12th June 2026.
+---
+
+## Changelog
+
+OpenMetadata 1.12.11 is a maintenance release delivering security patches, MCP improvements, AI enhancements, search fixes, UI enhancements, ingestion stability improvements, and connector updates.
+
+### 🔒 Security
+
+- **React-router-dom security upgrade** [#28677](https://github.com/open-metadata/OpenMetadata/pull/28677): Snyk security upgrade of react-router-dom from 6.30.3 to 6.30.4 to address reported vulnerabilities.
+- **Netty-bom bumped for CVE-2026-44249** [#28880](https://github.com/open-metadata/OpenMetadata/pull/28880): Updated netty-bom to 4.1.135.Final to resolve CVE-2026-44249.
+
+### 🔌 MCP (Model Context Protocol) Fixes
+
+- **Compact entity responses from create tools** [#28633](https://github.com/open-metadata/OpenMetadata/pull/28633): MCP create metric, test-case, and glossary tools now return a compact entity representation to reduce payload size.
+- **Compact entity response from create_article tool**: The create_article MCP tool now returns a compact entity representation, consistent with other create tools.
+- **Slim root_cause_analysis payload** [#28632](https://github.com/open-metadata/OpenMetadata/pull/28632): Reduced root_cause_analysis tool payload size to fit within LLM context limits.
+- **Return similarity score in search_metadata tool** [#28512](https://github.com/open-metadata/OpenMetadata/pull/28512): The search_metadata MCP tool now returns `_score` as `similarityScore` in results.
+- **Fix entityType filtering in search_metadata tool** [#28698](https://github.com/open-metadata/OpenMetadata/pull/28698): Resolved incorrect entity type filtering behavior in the search_metadata MCP tool.
+- **Fix OAuth state double-encoding in redirect URI** [#28953](https://github.com/open-metadata/OpenMetadata/pull/28953): Corrected OAuth state encoding to prevent double-encoding in MCP redirect URIs.
+
+### 🛠 API & Backend Fixes
+
+- **Fix duplicate query error in bulk APIs** [#25890](https://github.com/open-metadata/OpenMetadata/pull/25890): Resolved an error caused by duplicate queries being submitted through bulk API operations.
+- **Write server audit entries to audit.log** [#28782](https://github.com/open-metadata/OpenMetadata/pull/28782): Server audit events are now properly written to the audit.log file for observability and compliance.
+- **Fix SSE multi-line data field concatenation** [#28945](https://github.com/open-metadata/OpenMetadata/pull/28945): Multi-line SSE data fields are now correctly concatenated instead of being overwritten.
+- **Allow bare references to approved functions in SpEL conditions** [#28946](https://github.com/open-metadata/OpenMetadata/pull/28946): Policy engine now correctly evaluates bare function references in SpEL-based policy conditions.
+- **Drop unsupported om-event-layout from console appender**: Removed the unsupported `om-event-layout` configuration from the console appender to prevent startup warnings and misconfigurations.
+
+### 🔍 Search & Indexing Fixes
+
+- **Fix missing search aliases after reindex** [#28667](https://github.com/open-metadata/OpenMetadata/pull/28667): Resolved an issue where search aliases were missing after reindexing by atomically deleting the concrete index within the alias swap.
+- **Make users and admins searchable by email** [#28800](https://github.com/open-metadata/OpenMetadata/pull/28800): Users and admins can now be found via search using their email address.
+- **Re-derive tag fields on live tag-mutating updates** [#28900](https://github.com/open-metadata/OpenMetadata/pull/28900): Fixed an issue where `glossaryTags`, `classificationTags`, and `tier` were not re-derived correctly during live tag updates.
+- **Fix search preview inconsistent behavior** [#28589](https://github.com/open-metadata/OpenMetadata/pull/28589): Resolved inconsistent behavior in the entity search preview panel.
+
+### 🎨 UI & UX Fixes
+
+- **Restore import/export buttons for conditional EditAll policies** [#27488](https://github.com/open-metadata/OpenMetadata/pull/27488): Users with Data Producer roles using conditional policies (`isOwner()`, `hasDomain()`, `matchTeam()`) can now correctly see Import/Export options in the Glossary manage menu.
+- **Fix bulk-ops column grid showing soft-deleted entities** [#28653](https://github.com/open-metadata/OpenMetadata/pull/28653): Soft-deleted entities are now excluded from the bulk operations column grid.
+- **Brand name environment variable support** [#28624](https://github.com/open-metadata/OpenMetadata/pull/28624): UI now uses a `BRAND_NAME` environment variable in place of hardcoded "OpenMetadata" references for easier white-labeling.
+- **Fix Global Domain Filter translation** [#25982](https://github.com/open-metadata/OpenMetadata/pull/25982): Corrected translation for the Global Domain Filter UI element.
+- **Fix mixed language display when browser language differs from user setting** [#25962](https://github.com/open-metadata/OpenMetadata/pull/25962): Resolved an issue where UI displayed mixed languages when the browser language differed from the user's selected language.
+- **Fix SSO documentation format**: Corrected the format of SSO configuration documentation displayed in the UI.
+
+### ✈️ Ingestion Fixes
+
+- **Fix DagContext autoregister race in Airflow build_dag** [#28744](https://github.com/open-metadata/OpenMetadata/pull/28744): Resolved a race condition caused by DagContext autoregistration during DAG construction in Airflow APIs.
+- **Comprehensive diagnostics for Airflow connection check** [#28516](https://github.com/open-metadata/OpenMetadata/pull/28516): Added detailed diagnostic output to the Airflow connection check to help debug connectivity issues.
+- **Fix Iceberg/Delta metadata.json ingestion** [#28845](https://github.com/open-metadata/OpenMetadata/pull/28845): Corrected ingestion of Iceberg and Delta table metadata.json files to properly include real table columns.
+
+### 🔌 Connectors
+
+- **SSIS: optional databaseConnection for file-only mode** [#28708](https://github.com/open-metadata/OpenMetadata/pull/28708): The `databaseConnection` field is now optional in SSIS connector configuration, enabling file-only ingestion mode.
+- **Athena: catalogId support for S3 Tables and cross-account Glue catalogs** [#28956](https://github.com/open-metadata/OpenMetadata/pull/28956): Added `catalogId` support to Athena connection configuration for S3 Tables and cross-account Glue catalog access.
+- **SSIS: SQL Command, Execute SQL Task, Lookup task, and column-level lineage**: Extended SSIS connector with support for SQL Command tasks, Execute SQL Task, Lookup transformations, and column-level lineage extraction.
+
+### 🤖 AI Enhancements
+
+- **Documentation Agent sample data for descriptions**: The Documentation Agent now uses sample data when generating descriptions, improving the quality and relevance of AI-generated entity documentation.
+
+### 🐛 General Bug Fixes
+
+- **Fix tag FQN rewrite on entity rename** [#28725](https://github.com/open-metadata/OpenMetadata/pull/28725): Implemented boundary-aware idempotent tag FQN rewriting during entity rename operations to prevent incorrect partial matches.
+- **Preserve `secret:` prefix in Python SDK serialization** [#28625](https://github.com/open-metadata/OpenMetadata/pull/28625): Fixed Python SDK to preserve the `secret:` prefix during object serialization.
+- **Lineage: dedup queries and handle conflicts as warnings** [#28757](https://github.com/open-metadata/OpenMetadata/pull/28757): Lineage query deduplication is now applied, and already-present query conflicts are treated as warnings rather than errors.
+- **Fix data insights service filter on terms aggregation rebuild** [#28716](https://github.com/open-metadata/OpenMetadata/pull/28716): Data insights now correctly preserves the service filter when rebuilding terms aggregations.
+- **Fix alerts Entity FQN filter to match descendants** [#28833](https://github.com/open-metadata/OpenMetadata/pull/28833): Alert Entity FQN filters now correctly match against an entity and all of its descendants.
+- **Fix metadata-exporter credential decryption on re-dispatch**: Resolved an issue where the metadata exporter failed to decrypt credentials when re-dispatching export jobs.
+- **Fix notification template `<br>` line break preservation**: Corrected notification templates to properly preserve `<br>` line breaks instead of stripping them.

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -5,6 +5,11 @@
     "hasFeatures": true
   },
   {
+    "version": "v1.12.11",
+    "date": "Released on 12th June 2026.",
+    "hasFeatures": false
+  },
+  {
     "version": "v1.12.10",
     "date": "Released on 3rd June 2026.",
     "hasFeatures": false


### PR DESCRIPTION
## Summary

- Adds `content/product-updates/v1.12.11.md` with full release notes for OpenMetadata v1.12.11 (Released on 12th June 2026)
- Updates `versions.json` to include the v1.12.11 entry

Covers both OSS and Collate-side changes across Security, MCP, AI Enhancements, Search & Indexing, UI & UX, Ingestion, Connectors, and Bug Fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)