### PR TITLE
Restore Mango to case-studies banner; move FreeNow to quote grid

### DIFF
--- a/src/constants/CustomerGallery.constants.tsx
+++ b/src/constants/CustomerGallery.constants.tsx
@@ -1,7 +1,19 @@
 const HEADER_IMAGE_ROUTE = '/assets/customer-gallery/header';
 const GALLERY_IMAGE_ROUTE = '/assets/testimonials';
 
-export const HEADER_CUSTOMERS = [
+type HeaderCustomer = {
+    backgroundImage: string;
+    logo: string;
+    title: string;
+    buttonText: string;
+    url: string;
+    isExternal: boolean;
+    button2Text?: string;
+    url2?: string;
+    isExternal2?: boolean;
+};
+
+export const HEADER_CUSTOMERS: HeaderCustomer[] = [
     {
         backgroundImage: `${HEADER_IMAGE_ROUTE}/openai-bg.png`,
         logo: `${HEADER_IMAGE_ROUTE}/openai-logo.svg`,

--- a/src/constants/CustomerGallery.constants.tsx
+++ b/src/constants/CustomerGallery.constants.tsx
@@ -35,15 +35,12 @@ export const HEADER_CUSTOMERS = [
         isExternal: false
     },
     {
-        backgroundImage: `${HEADER_IMAGE_ROUTE}/freenow-bg.svg`,
-        logo: `${HEADER_IMAGE_ROUTE}/freenow-logo.svg`,
-        title: '7 business domains, managed with 30+ analytics process per domain',
-        buttonText: 'FREENOW Blog',
-        url: 'https://medium.com/breaking-data-silos-lineage-for-cross-domain/data-management-at-freenow-the-lineage-and-announcements-approach-177f387a9180',
-        button2Text: 'Read More',
-        url2: '/case-study/freenow',
-        isExternal: true,
-        isExternal2: false
+        backgroundImage: `${HEADER_IMAGE_ROUTE}/mango-bg.svg`,
+        logo: `${HEADER_IMAGE_ROUTE}/mango-logo.svg`,
+        title: 'Mango increases productivity of data teams up to 20%',
+        buttonText: 'Read More',
+        url: 'https://www.getcollate.io/customers/mango',
+        isExternal: true
     },
 ]
 
@@ -57,6 +54,19 @@ export const INDUSTRY_LIST = [
 ]
 
 export const CUSTOMER_GALLERY = [
+    {
+        logo: `${GALLERY_IMAGE_ROUTE}/freenow-logo.png`,
+        industry: 'Transportation',
+        testimonial: "We’re not trying to communicate more—we’re trying to communicate better and more efficiently. With OpenMetadata, we’ve created a centralized, automated communication hub that gives full visibility into data asset changes and their impact across the organization.",
+        customerName: 'Mehak Roha',
+        customerDesignation: 'Data Platform Engineer',
+        company: 'FreeNow',
+        imgSize: {
+            width: 150,
+            height: 50
+        },
+        link: '/case-study/freenow'
+    },
     {
         logo: `${GALLERY_IMAGE_ROUTE}/woop-logo.webp`,
         industry: 'Transportation',

--- a/src/pages/case-studies.tsx
+++ b/src/pages/case-studies.tsx
@@ -103,7 +103,7 @@ const CaseStudiesPage = () => {
                         {customer.buttonText}
                       </div>
                     </ParamLink>
-                    {customer.button2Text && (
+                    {customer.button2Text && customer.url2 && (
                       <ParamLink href={customer.url2} target={customer.isExternal2 ? '_blank' : '_self'}>
                         <div className="mt-5 mb-2 rounded-[3px] font-medium tracking-[-0.02em] mx-2 border-2 border-[#7147E8] max-w-fit px-4 py-2 text-[#7147E8] whitespace-nowrap">
                           {customer.button2Text}


### PR DESCRIPTION
## What

Mango was dropped from the top banners on `/case-studies` when the OpenAI case study (#375) took its slot. This restores Mango to the banner and keeps the banner at a clean five cards by demoting **FreeNow** to the quote grid.

## Changes (`CustomerGallery.constants.tsx`)
- **`HEADER_CUSTOMERS`** — FreeNow card replaced with the restored Mango card (assets already in repo; links to `getcollate.io/customers/mango`).
- **`CUSTOMER_GALLERY`** — new FreeNow testimonial card (quote from `FreenowCustomer.constants`, Mehak Roha; Transportation; links to `/case-study/freenow`).

Banner now reads: OpenAI · Carrefour (featured) · Loggi · Wix · Mango.

## Note
FreeNow's banner previously had a second button linking to their Medium blog. A quote card holds one link, so it now points to the FreeNow case study; the Medium blog button is dropped from this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)