### PR TITLE
docs: add release notes for OpenMetadata v1.12.12

### DIFF
--- a/content/product-updates/v1.12.12.md
+++ b/content/product-updates/v1.12.12.md
@@ -22,13 +22,13 @@ OpenMetadata 1.12.12 is a maintenance release delivering security patches, searc
 
 - **Cap oversized dataModel column trees at index time** [#29212](https://github.com/open-metadata/OpenMetadata/pull/29212): Containers/tables with pathologically large dataModel schemas (hundreds of thousands of columns) produced multi-hundred-MB search documents that could OOM the server on read/reindex. The oversized-doc guard now also strips nested column children and derived `columnNames`/`columnNamesFuzzy` once a doc is still over the cap after lineage stripping. Top-level columns and the full schema (via the entity API) are preserved.
 - **Column tag filtering in advanced search** [#28871](https://github.com/open-metadata/OpenMetadata/pull/28871): Added column-tag filtering to advanced search.
-- **Defer row fetch in audit logs list query** [#28850](https://github.com/open-metadata/OpenMetadata/pull/28850): Avoids a full-row scan when listing audit logs.
+- **Defer row fetch in audit logs list query** [#28851](https://github.com/open-metadata/OpenMetadata/pull/28851): Avoids a full-row scan when listing audit logs.
 - **AuditLogConsumer dropping events on offset gaps** [#29252](https://github.com/open-metadata/OpenMetadata/pull/29252): `change_event.offset` is AUTO_INCREMENT/SERIAL and only visible at commit, so under concurrent writes a lower offset can become visible after a higher one. The consumer no longer skips audit events across these offset gaps.
 
 ### 🧬 Lineage
 
 - **Render traced edges and nodes** [#29195](https://github.com/open-metadata/OpenMetadata/pull/29195): Lineage now visually renders traced edges and nodes.
-- **Restore edges in lineage PNG export** [#29124](https://github.com/open-metadata/OpenMetadata/pull/29124): Edges are restored after canvas re-render in the lineage PNG export.
+- **Restore edges in lineage PNG export** [#29250](https://github.com/open-metadata/OpenMetadata/pull/29250): Edges are restored after canvas re-render in the lineage PNG export.
 - **Fix selector for export lineage** [5b4fe8c](https://github.com/open-metadata/OpenMetadata/commit/5b4fe8c446): Fixed the selector used for lineage export.
 - **Correct nodeDepth for fetched nodes** [#27477](https://github.com/open-metadata/OpenMetadata/pull/27477): Updates nodeDepth on fetched nodes using the base nodeDepth (Issue #25388).
 
@@ -42,7 +42,7 @@ OpenMetadata 1.12.12 is a maintenance release delivering security patches, searc
 ### 🔐 Authentication
 
 - **MCP OAuth login fails with 400 on id_token fragment** [#29228](https://github.com/open-metadata/OpenMetadata/pull/29228): Fixed `/mcp/callback` handling of the active-session shortcut and implicit-flow `id_token` returned in the URL fragment by SSO.
-- **OIDC/SAML self-signup persists mapped email claim** [#29189](https://github.com/open-metadata/OpenMetadata/pull/29189): Self-signup now persists the mapped email claim from OIDC/SAML.
+- **OIDC/SAML self-signup persists mapped email claim** [#29227](https://github.com/open-metadata/OpenMetadata/pull/29227): Self-signup now persists the mapped email claim from OIDC/SAML.
 
 ### 🛡️ Data Governance & Quality
 

--- a/content/product-updates/v1.12.12.md
+++ b/content/product-updates/v1.12.12.md
@@ -1,0 +1,61 @@
+---
+id: 98
+version: v1.12.12
+date: Released on 24th June 2026.
+---
+
+## 🔒 Security
+
+- **sudo upgraded for CVE-2026-35535** [#29343](https://github.com/open-metadata/OpenMetadata/pull/29343): Upgraded sudo in the ingestion image to patch CVE-2026-35535.
+- **Spring, Micrometer & OpenTelemetry CVE patches** [#29111](https://github.com/open-metadata/OpenMetadata/pull/29111): Spring 6.2.18 → 6.2.19 (CVE-2026-41850, CVE-2026-41851), Micrometer 1.14.5 → 1.15.12, and pinned OpenTelemetry to patch reported CVEs.
+- **ws bumped for CVE-2026-48779** [#29122](https://github.com/open-metadata/OpenMetadata/pull/29122): Updated `ws` to 8.21.0.
+- **handlebars bumped for CVE-2026-55760** [#29221](https://github.com/open-metadata/OpenMetadata/pull/29221): Updated handlebars to 4.5.2 to patch a path-traversal vulnerability.
+- **form-data bumped** [#29349](https://github.com/open-metadata/OpenMetadata/pull/29349): Updated the `form-data` package to address reported vulnerabilities.
+- **markdown-it bumped** [#29057](https://github.com/open-metadata/OpenMetadata/pull/29057): markdown-it 14.1.1 → 14.2.0.
+- **UI dependency vulnerability fixes** [#29223](https://github.com/open-metadata/OpenMetadata/pull/29223): Addressed assorted UI vulnerabilities, including undici 6.25.0 → 6.27.0 and form-data updates.
+
+## 🔍 Search & Performance
+
+- **Cap oversized dataModel column trees at index time** [#29212](https://github.com/open-metadata/OpenMetadata/pull/29212): Containers/tables with pathologically large dataModel schemas (hundreds of thousands of columns) produced multi-hundred-MB search documents that could OOM the server on read/reindex. The oversized-doc guard now also strips nested column children and derived `columnNames`/`columnNamesFuzzy` once a doc is still over the cap after lineage stripping. Top-level columns and the full schema (via the entity API) are preserved.
+- **Column tag filtering in advanced search** [#28871](https://github.com/open-metadata/OpenMetadata/pull/28871): Added column-tag filtering to advanced search.
+- **Defer row fetch in audit logs list query** [#28850](https://github.com/open-metadata/OpenMetadata/pull/28850): Avoids a full-row scan when listing audit logs.
+- **AuditLogConsumer dropping events on offset gaps** [#29252](https://github.com/open-metadata/OpenMetadata/pull/29252): `change_event.offset` is AUTO_INCREMENT/SERIAL and only visible at commit, so under concurrent writes a lower offset can become visible after a higher one. The consumer no longer skips audit events across these offset gaps.
+
+## 🧬 Lineage
+
+- **Render traced edges and nodes** [#29195](https://github.com/open-metadata/OpenMetadata/pull/29195): Lineage now visually renders traced edges and nodes.
+- **Restore edges in lineage PNG export** [#29124](https://github.com/open-metadata/OpenMetadata/pull/29124): Edges are restored after canvas re-render in the lineage PNG export.
+- **Fix selector for export lineage** [5b4fe8c](https://github.com/open-metadata/OpenMetadata/commit/5b4fe8c446): Fixed the selector used for lineage export.
+- **Correct nodeDepth for fetched nodes** [#27477](https://github.com/open-metadata/OpenMetadata/pull/27477): Updates nodeDepth on fetched nodes using the base nodeDepth (Issue #25388).
+
+## 📖 Glossary
+
+- **Approve/reject buttons missing after Expand All** [#29292](https://github.com/open-metadata/OpenMetadata/pull/29292): The Expand-All tree fetch omitted the `reviewers` field, so nested In-Review terms lost their approve/reject buttons. Reviewers are now requested so the buttons remain for nested terms.
+- **Approval re-triggers on approved-term rename** [1755135](https://github.com/open-metadata/OpenMetadata/commit/1755135e6e): Renaming an already-approved term now records name/parent on the change description so the approval workflow re-triggers correctly.
+- **Keep approvals valid after move** [#29234](https://github.com/open-metadata/OpenMetadata/pull/29234): Approvals remain valid after a glossary term is moved.
+- **Cascade glossary rename to child terms in search index** [#29134](https://github.com/open-metadata/OpenMetadata/pull/29134): Renaming a glossary now updates the denormalized `glossary.name` / `glossary.fullyQualifiedName` on every child term's search-index doc.
+
+## 🔐 Authentication
+
+- **MCP OAuth login fails with 400 on id_token fragment** [#29228](https://github.com/open-metadata/OpenMetadata/pull/29228): Fixed `/mcp/callback` handling of the active-session shortcut and implicit-flow `id_token` returned in the URL fragment by SSO.
+- **OIDC/SAML self-signup persists mapped email claim** [#29189](https://github.com/open-metadata/OpenMetadata/pull/29189): Self-signup now persists the mapped email claim from OIDC/SAML.
+
+## 🛡️ Data Governance & Quality
+
+- **Preserve data products across domain deletes** [#29138](https://github.com/open-metadata/OpenMetadata/pull/29138): When a data product's domain was changed and the original domain was then recursively hard-deleted, the data product was incorrectly deleted via a stale domain→dataProduct relationship. The stale relationship is now removed so data products are preserved.
+- **Delete orphaned test cases + guard test-definition deletion** [#29081](https://github.com/open-metadata/OpenMetadata/pull/29081): Orphaned test cases (whose testDefinition relationship was removed) can now be hard-deleted, and test-definition deletion is guarded against the missing relationship.
+
+## ⚙️ Apps & Ingestion
+
+- **Sync IngestionPipeline scheduleInterval on app schedule changes** [#28702](https://github.com/open-metadata/OpenMetadata/pull/28702): When an external app's schedule changes (scheduled→manual or a cron edit), the backing IngestionPipeline `scheduleInterval` is now synced so K8s/Argo/Hybrid runners pick up the new schedule.
+- **Skip CSV consolidation without a previous version** [#29088](https://github.com/open-metadata/OpenMetadata/pull/29088): Avoids CSV consolidation when there is no previous version to consolidate against.
+
+## 🎛️ UI
+
+- **Scope "between" operator fix to numeric custom properties** [#29334](https://github.com/open-metadata/OpenMetadata/pull/29334): The `between` operator now correctly sends the upper bound for numeric custom properties only (Issue #27482).
+
+## 🔌 Connectors
+
+- **Snowflake: create Query entities in ACCESS_HISTORY lineage** [#29125](https://github.com/open-metadata/OpenMetadata/pull/29125): The opt-in ACCESS_HISTORY lineage path now emits a `CreateQueryRequest` per edge so the originating SQL surfaces as Query entities, and fixes a probe issue.
+- **Snowflake: forward-port ACCESS_HISTORY lineage + cache fixes** [#29036](https://github.com/open-metadata/OpenMetadata/pull/29036): Forward-ports the opt-in ACCESS_HISTORY lineage path and cache fixes.
+- **Metabase: StarRocks SQL dialect for lineage** [#29033](https://github.com/open-metadata/OpenMetadata/pull/29033): StarRocks connections now route to the StarRocks SQL dialect so StarRocks-specific syntax in Metabase native queries (e.g. `to_bitmap()`, `bitmap_union_count()`) parses correctly for lineage (Issue #28934).

--- a/content/product-updates/v1.12.12.md
+++ b/content/product-updates/v1.12.12.md
@@ -4,7 +4,11 @@ version: v1.12.12
 date: Released on 24th June 2026.
 ---
 
-## 🔒 Security
+## Changelog
+
+OpenMetadata 1.12.12 is a maintenance release delivering security patches, MCP improvements, AI enhancements, search fixes, UI enhancements, ingestion stability improvements, and connector updates.
+
+### 🔒 Security
 
 - **sudo upgraded for CVE-2026-35535** [#29343](https://github.com/open-metadata/OpenMetadata/pull/29343): Upgraded sudo in the ingestion image to patch CVE-2026-35535.
 - **Spring, Micrometer & OpenTelemetry CVE patches** [#29111](https://github.com/open-metadata/OpenMetadata/pull/29111): Spring 6.2.18 → 6.2.19 (CVE-2026-41850, CVE-2026-41851), Micrometer 1.14.5 → 1.15.12, and pinned OpenTelemetry to patch reported CVEs.
@@ -14,47 +18,47 @@ date: Released on 24th June 2026.
 - **markdown-it bumped** [#29057](https://github.com/open-metadata/OpenMetadata/pull/29057): markdown-it 14.1.1 → 14.2.0.
 - **UI dependency vulnerability fixes** [#29223](https://github.com/open-metadata/OpenMetadata/pull/29223): Addressed assorted UI vulnerabilities, including undici 6.25.0 → 6.27.0 and form-data updates.
 
-## 🔍 Search & Performance
+### 🔍 Search & Performance
 
 - **Cap oversized dataModel column trees at index time** [#29212](https://github.com/open-metadata/OpenMetadata/pull/29212): Containers/tables with pathologically large dataModel schemas (hundreds of thousands of columns) produced multi-hundred-MB search documents that could OOM the server on read/reindex. The oversized-doc guard now also strips nested column children and derived `columnNames`/`columnNamesFuzzy` once a doc is still over the cap after lineage stripping. Top-level columns and the full schema (via the entity API) are preserved.
 - **Column tag filtering in advanced search** [#28871](https://github.com/open-metadata/OpenMetadata/pull/28871): Added column-tag filtering to advanced search.
 - **Defer row fetch in audit logs list query** [#28850](https://github.com/open-metadata/OpenMetadata/pull/28850): Avoids a full-row scan when listing audit logs.
 - **AuditLogConsumer dropping events on offset gaps** [#29252](https://github.com/open-metadata/OpenMetadata/pull/29252): `change_event.offset` is AUTO_INCREMENT/SERIAL and only visible at commit, so under concurrent writes a lower offset can become visible after a higher one. The consumer no longer skips audit events across these offset gaps.
 
-## 🧬 Lineage
+### 🧬 Lineage
 
 - **Render traced edges and nodes** [#29195](https://github.com/open-metadata/OpenMetadata/pull/29195): Lineage now visually renders traced edges and nodes.
 - **Restore edges in lineage PNG export** [#29124](https://github.com/open-metadata/OpenMetadata/pull/29124): Edges are restored after canvas re-render in the lineage PNG export.
 - **Fix selector for export lineage** [5b4fe8c](https://github.com/open-metadata/OpenMetadata/commit/5b4fe8c446): Fixed the selector used for lineage export.
 - **Correct nodeDepth for fetched nodes** [#27477](https://github.com/open-metadata/OpenMetadata/pull/27477): Updates nodeDepth on fetched nodes using the base nodeDepth (Issue #25388).
 
-## 📖 Glossary
+### 📖 Glossary
 
 - **Approve/reject buttons missing after Expand All** [#29292](https://github.com/open-metadata/OpenMetadata/pull/29292): The Expand-All tree fetch omitted the `reviewers` field, so nested In-Review terms lost their approve/reject buttons. Reviewers are now requested so the buttons remain for nested terms.
 - **Approval re-triggers on approved-term rename** [1755135](https://github.com/open-metadata/OpenMetadata/commit/1755135e6e): Renaming an already-approved term now records name/parent on the change description so the approval workflow re-triggers correctly.
 - **Keep approvals valid after move** [#29234](https://github.com/open-metadata/OpenMetadata/pull/29234): Approvals remain valid after a glossary term is moved.
 - **Cascade glossary rename to child terms in search index** [#29134](https://github.com/open-metadata/OpenMetadata/pull/29134): Renaming a glossary now updates the denormalized `glossary.name` / `glossary.fullyQualifiedName` on every child term's search-index doc.
 
-## 🔐 Authentication
+### 🔐 Authentication
 
 - **MCP OAuth login fails with 400 on id_token fragment** [#29228](https://github.com/open-metadata/OpenMetadata/pull/29228): Fixed `/mcp/callback` handling of the active-session shortcut and implicit-flow `id_token` returned in the URL fragment by SSO.
 - **OIDC/SAML self-signup persists mapped email claim** [#29189](https://github.com/open-metadata/OpenMetadata/pull/29189): Self-signup now persists the mapped email claim from OIDC/SAML.
 
-## 🛡️ Data Governance & Quality
+### 🛡️ Data Governance & Quality
 
 - **Preserve data products across domain deletes** [#29138](https://github.com/open-metadata/OpenMetadata/pull/29138): When a data product's domain was changed and the original domain was then recursively hard-deleted, the data product was incorrectly deleted via a stale domain→dataProduct relationship. The stale relationship is now removed so data products are preserved.
 - **Delete orphaned test cases + guard test-definition deletion** [#29081](https://github.com/open-metadata/OpenMetadata/pull/29081): Orphaned test cases (whose testDefinition relationship was removed) can now be hard-deleted, and test-definition deletion is guarded against the missing relationship.
 
-## ⚙️ Apps & Ingestion
+### ⚙️ Apps & Ingestion
 
 - **Sync IngestionPipeline scheduleInterval on app schedule changes** [#28702](https://github.com/open-metadata/OpenMetadata/pull/28702): When an external app's schedule changes (scheduled→manual or a cron edit), the backing IngestionPipeline `scheduleInterval` is now synced so K8s/Argo/Hybrid runners pick up the new schedule.
 - **Skip CSV consolidation without a previous version** [#29088](https://github.com/open-metadata/OpenMetadata/pull/29088): Avoids CSV consolidation when there is no previous version to consolidate against.
 
-## 🎛️ UI
+### 🎛️ UI
 
 - **Scope "between" operator fix to numeric custom properties** [#29334](https://github.com/open-metadata/OpenMetadata/pull/29334): The `between` operator now correctly sends the upper bound for numeric custom properties only (Issue #27482).
 
-## 🔌 Connectors
+### 🔌 Connectors
 
 - **Snowflake: create Query entities in ACCESS_HISTORY lineage** [#29125](https://github.com/open-metadata/OpenMetadata/pull/29125): The opt-in ACCESS_HISTORY lineage path now emits a `CreateQueryRequest` per edge so the originating SQL surfaces as Query entities, and fixes a probe issue.
 - **Snowflake: forward-port ACCESS_HISTORY lineage + cache fixes** [#29036](https://github.com/open-metadata/OpenMetadata/pull/29036): Forward-ports the opt-in ACCESS_HISTORY lineage path and cache fixes.

--- a/content/product-updates/v1.12.12.md
+++ b/content/product-updates/v1.12.12.md
@@ -6,7 +6,7 @@ date: Released on 24th June 2026.
 
 ## Changelog
 
-OpenMetadata 1.12.12 is a maintenance release delivering security patches, MCP improvements, AI enhancements, search fixes, UI enhancements, ingestion stability improvements, and connector updates.
+OpenMetadata 1.12.12 is a maintenance release delivering security patches, search and performance improvements, lineage and UI enhancements, and connector updates.
 
 ### 🔒 Security
 

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -5,6 +5,11 @@
     "hasFeatures": true
   },
   {
+    "version": "v1.12.12",
+    "date": "Released on 24th June 2026.",
+    "hasFeatures": false
+  },
+  {
     "version": "v1.12.11",
     "date": "Released on 12th June 2026.",
     "hasFeatures": false


### PR DESCRIPTION
This pull request adds the release notes for version `v1.12.12` (24th June 2026) and updates the product updates version list. The release includes important security patches, search and performance improvements, lineage visualization fixes, glossary workflow enhancements, authentication bug fixes, data governance improvements, ingestion pipeline synchronization, UI bugfixes, and connector updates.

**Release notes and documentation:**

* Added `v1.12.12` release notes file with detailed changelog, covering security updates, performance, lineage, glossary, authentication, data governance, ingestion, UI, and connectors.
* Updated `versions.json` to include `v1.12.12` with release date and feature flag.

**Key highlights from the release notes:**

**Security fixes:**
- Upgraded dependencies to address multiple CVEs, including `sudo`, Spring, Micrometer, OpenTelemetry, `ws`, `handlebars`, `form-data`, and `markdown-it`, plus assorted UI dependency vulnerabilities.

**Search & performance:**
- Limited oversized dataModel column trees at index time to prevent OOM errors, improved audit log queries, and fixed audit event dropping on offset gaps.

**Lineage & glossary:**
- Improved lineage visualization and export, fixed glossary term approval workflows, and ensured glossary renames cascade to child terms in the search index.

**Authentication & governance:**
- Fixed OAuth login and self-signup email mapping, preserved data products across domain deletes, and improved test case deletion logic.

**Apps, UI, and connectors:**
- Synced ingestion pipeline schedules with external app changes, fixed UI "between" operator for numeric custom properties, and enhanced connector lineage features for Snowflake and Metabase.