### PR TITLE
docs: add release notes for OpenMetadata v1.13.1

### DIFF
--- a/content/product-updates/v1.13.1.md
+++ b/content/product-updates/v1.13.1.md
@@ -140,7 +140,6 @@ OpenMetadata 1.13.1 is a maintenance release delivering MCP tool improvements, s
 
 ### 🎛️ UI
 
-- **White-label brand name support** [#28624](https://github.com/open-metadata/OpenMetadata/pull/28624) [#28815](https://github.com/open-metadata/OpenMetadata/pull/28815): Replaced hardcoded "OpenMetadata" display strings with a configurable `BRAND_NAME` environment variable across all locale files and UI components, enabling downstream forks and OEMs to white-label the product name without code changes.
 - **Prevent ontology graph crash on large glossaries** [#29270](https://github.com/open-metadata/OpenMetadata/pull/29270): Prevented the ontology relations graph from crashing on large glossaries.
 - **Block-editor link modal in drawers** [#29374](https://github.com/open-metadata/OpenMetadata/pull/29374): Kept the link modal usable inside focus-trapping drawers.
 - **Preserve Persona navigation ordering** [#29353](https://github.com/open-metadata/OpenMetadata/pull/29353): Saved Persona navigation ordering is now preserved on reload.

--- a/content/product-updates/v1.13.1.md
+++ b/content/product-updates/v1.13.1.md
@@ -6,7 +6,18 @@ date: Released on 27th June 2026.
 
 ## Changelog
 
-OpenMetadata 1.13.1 is a maintenance release focused on MCP tool reliability, search improvements, and platform stability.
+OpenMetadata 1.13.1 is a maintenance release delivering MCP tool improvements, search and reindexing fixes, security patches, connector updates, glossary and governance enhancements, and UI fixes.
+
+### 🔒 Security
+
+- **Netty CVE-2026-44249** [#28880](https://github.com/open-metadata/OpenMetadata/pull/28880): Bumped `netty-bom` to 4.1.135.Final.
+- **Jackson-databind CVE-2026-54512/513/514** [#29389](https://github.com/open-metadata/OpenMetadata/pull/29389): Bumped `jackson-databind` from 2.18.7 to 2.18.8.
+- **Spring, Micrometer & OpenTelemetry CVE patches** [#29111](https://github.com/open-metadata/OpenMetadata/pull/29111): Spring 6.2.18 → 6.2.19, Micrometer upgraded, and OpenTelemetry pinned to patch reported CVEs.
+- **ws CVE-2026-48779** [#29122](https://github.com/open-metadata/OpenMetadata/pull/29122): Bumped `ws` to 8.21.0.
+- **handlebars CVE-2026-55760** [#29221](https://github.com/open-metadata/OpenMetadata/pull/29221): Bumped `handlebars` to 4.5.2 to patch a path-traversal vulnerability.
+- **sudo CVE-2026-35535** [#29343](https://github.com/open-metadata/OpenMetadata/pull/29343): Upgraded `sudo` in the ingestion Docker image.
+- **UI dependency vulnerability fixes** [#29223](https://github.com/open-metadata/OpenMetadata/pull/29223) [#29241](https://github.com/open-metadata/OpenMetadata/pull/29241): Bumped `undici` 6.25.0 → 6.27.0, `form-data`, `dompurify`, `markdown-it`, and `js-yaml`.
+- **form-data bumped** [#29349](https://github.com/open-metadata/OpenMetadata/pull/29349): Updated the `form-data` package to address reported vulnerabilities.
 
 ### 🤖 MCP (Model Context Protocol)
 
@@ -22,17 +33,121 @@ OpenMetadata 1.13.1 is a maintenance release focused on MCP tool reliability, se
 - **Search test cases and test suites via search_metadata** [#28743](https://github.com/open-metadata/OpenMetadata/pull/28743): `search_metadata` now supports searching test cases and test suites.
 - **Shared trim util and global response size-budget** [#28764](https://github.com/open-metadata/OpenMetadata/pull/28764): Introduced shared response-trim utilities and a global size-budget net across all MCP tools.
 - **Trim wide-table payload in get_entity_details** [#28776](https://github.com/open-metadata/OpenMetadata/pull/28776): `get_entity_details` now trims wide-table payloads (column descriptions, schema/model SQL) to stay within size budgets.
+- **MCP OAuth login fix** [#29228](https://github.com/open-metadata/OpenMetadata/pull/29228): Fixed `/mcp/callback` handling of the active-session shortcut and implicit-flow `id_token` returned in the URL fragment by SSO.
+- **Fix OAuth state double-encoding** [#28952](https://github.com/open-metadata/OpenMetadata/pull/28952): OAuth state is now echoed without double-encoding in the redirect URI.
 
-### 🔍 Search
+### 🔍 Search & Reindexing
 
 - **Vectorize testSuite/testCase for hybrid search** [#28669](https://github.com/open-metadata/OpenMetadata/pull/28669): Test suites and test cases are now vectorized, enabling hybrid (keyword + semantic) search over data quality entities.
 - **Make users and admins searchable by email** [#28800](https://github.com/open-metadata/OpenMetadata/pull/28800): Users and admins are now searchable by their email address.
+- **Recreate all indexes on major/minor version upgrade** [#28885](https://github.com/open-metadata/OpenMetadata/pull/28885): All search indexes are now recreated on major or minor version upgrades to pick up mapping changes.
+- **Reindex-drift and index health checks** [#28856](https://github.com/open-metadata/OpenMetadata/pull/28856): Added reindex-drift detection and index health checks in `/system/validate`.
+- **Fix reindex OOM on wide tables** [#28888](https://github.com/open-metadata/OpenMetadata/pull/28888): Switched to a covering cursor query and added entity name indexes to prevent out-of-sort-memory errors during reindex.
+- **Re-add --recreate-indexes flag** [#29087](https://github.com/open-metadata/OpenMetadata/pull/29087): Restored the `--recreate-indexes` flag to the reindex CLI for backward compatibility.
+- **Staged-index rescue uses index_total** [#29108](https://github.com/open-metadata/OpenMetadata/pull/29108): Uses `index_total` instead of `docs.count` for staged-index rescue so a failed reindex doesn't delete a populated index.
+- **Never apply refresh_interval=-1 as live serving value** [#29153](https://github.com/open-metadata/OpenMetadata/pull/29153): Prevents `refresh_interval=-1` from being applied as a live serving value on index promote.
+- **Cap oversized dataModel column tree at index time** [#29212](https://github.com/open-metadata/OpenMetadata/pull/29212): Containers/tables with pathologically large dataModel schemas now have nested column children stripped at index time to prevent OOM.
+- **Regenerate embeddings on dimension change** [#29437](https://github.com/open-metadata/OpenMetadata/pull/29437): Embeddings are regenerated when vector dimensions change instead of reusing stale vectors.
+- **Backfill name indexes for distributed reindex pagination** [#29361](https://github.com/open-metadata/OpenMetadata/pull/29361): Name indexes are backfilled to support distributed reindex pagination.
+- **Bound column-index fan-out** [#29377](https://github.com/open-metadata/OpenMetadata/pull/29377): Bounded table column-index fan-out to prevent reindex OOM on wide tables.
+- **Surface exact/prefix matches first in QuickFilter** [#29231](https://github.com/open-metadata/OpenMetadata/pull/29231): QuickFilter aggregations now surface exact and prefix matches first.
+- **Extend best-match ordering to sourceFields/topHits** [#29296](https://github.com/open-metadata/OpenMetadata/pull/29296): Extended the best-match ordering logic to sourceFields and topHits requests.
+- **My Data defaults to dataAsset index** [#29209](https://github.com/open-metadata/OpenMetadata/pull/29209): Changed the My Data page from the `all` index to `dataAsset` for more relevant results.
+- **Stop time-series field propagation** [#29499](https://github.com/open-metadata/OpenMetadata/pull/29499): Stopped time-series field propagation to prevent stale data in downstream indexes.
+
+### 🔌 Connectors & Ingestion
+
+- **PowerBI datamarts support** [#28896](https://github.com/open-metadata/OpenMetadata/pull/28896): Added support for Power BI datamarts.
+- **Fivetran improvements** [#27270](https://github.com/open-metadata/OpenMetadata/pull/27270): Various improvements to the Fivetran connector.
+- **Athena: pass catalogId for S3 Tables enumeration** [#28929](https://github.com/open-metadata/OpenMetadata/pull/28929): Passes `catalogId` to `get_tables` for Athena S3 Tables enumeration.
+- **Athena: ingest Iceberg table properties** [#27715](https://github.com/open-metadata/OpenMetadata/pull/27715): Ingests Iceberg table properties from the `$properties` metatable.
+- **Athena: remove Trino stats** [#29446](https://github.com/open-metadata/OpenMetadata/pull/29446): Removed Trino-specific stats from the Athena table profiler.
+- **MySQL: refresh RDS IAM auth token per connection** [#28730](https://github.com/open-metadata/OpenMetadata/pull/28730): IAM auth tokens are now refreshed per connection instead of reusing stale tokens.
+- **MySQL: default stored-procedure language to SQL** [#28898](https://github.com/open-metadata/OpenMetadata/pull/28898): Unknown stored-procedure languages now default to SQL instead of `None`.
+- **MySQL: parameterize routines query** [#29077](https://github.com/open-metadata/OpenMetadata/pull/29077): Parameterized the MySQL routines query to avoid SQL string interpolation.
+- **Metabase: StarRocks SQL dialect for lineage** [#29033](https://github.com/open-metadata/OpenMetadata/pull/29033): StarRocks connections now route to the StarRocks SQL dialect so StarRocks-specific syntax parses correctly for lineage.
+- **Metabase: strip optional clause blocks** [#29390](https://github.com/open-metadata/OpenMetadata/pull/29390): Strips `[[...]]` optional clause blocks before lineage parsing.
+- **Datalake: parse array type nested structures in JSON** [#27798](https://github.com/open-metadata/OpenMetadata/pull/27798): Fixed parsing of array type nested structure fields inside JSON files.
+- **Iceberg/Delta: ingest metadata.json with real table columns** [#28422](https://github.com/open-metadata/OpenMetadata/pull/28422): Iceberg/Delta `metadata.json` files are now ingested with real table columns instead of placeholder schema.
+- **Upgrade collate-sqllineage** [#27413](https://github.com/open-metadata/OpenMetadata/pull/27413): Upgraded `collate-sqllineage` to ≥2.1.1 with regression tests.
+- **OpenLineage: reset Kinesis poll inactivity timer** [#29276](https://github.com/open-metadata/OpenMetadata/pull/29276): Resets the Kinesis poll inactivity timer per shard to prevent premature stream abandonment.
+- **OpenLineage: de-aggregate KPL records** [#29037](https://github.com/open-metadata/OpenMetadata/pull/29037): De-aggregates KPL (Kinesis Producer Library) records in the Kinesis source.
+- **SAP HANA: profiler fix** [#27483](https://github.com/open-metadata/OpenMetadata/pull/27483): Fixed `CREATE_TIME` lookup to use `SYS.TABLES` with uppercase catalog matching.
+- **Unity Catalog: incremental extraction flag** [#28906](https://github.com/open-metadata/OpenMetadata/pull/28906): Added the missing `supportsIncrementalMetadataExtraction` flag.
+- **dbt Cloud: stale FQN and null timestamp** [#29525](https://github.com/open-metadata/OpenMetadata/pull/29525): Fixed dbt Cloud pipeline status using stale FQN and null timestamp.
+- **Secret serialization fixes** [#28625](https://github.com/open-metadata/OpenMetadata/pull/28625) [#29198](https://github.com/open-metadata/OpenMetadata/pull/29198) [#29216](https://github.com/open-metadata/OpenMetadata/pull/29216): Preserved `secret:` prefix during Python SDK serialization, handled empty connection passwords with `CustomSecretStr`, and hardened serialization for null secrets.
+- **Fix lineage script_exception in ADD_UPDATE_LINEAGE** [open-metadata/openmetadata-collate#4481](https://github.com/open-metadata/openmetadata-collate/pull/4481): Fixed script exceptions during lineage add/update operations.
+
+### 📖 Glossary
+
+- **Cascade glossary rename to child terms in search index** [#29159](https://github.com/open-metadata/OpenMetadata/pull/29159): Renaming a glossary now updates the denormalized `glossary.name` / `glossary.fullyQualifiedName` on every child term's search-index doc.
+- **Keep approvals valid after move** [#29214](https://github.com/open-metadata/OpenMetadata/pull/29214): Approvals remain valid after a glossary term is moved.
+- **Skip move consolidation** [#29266](https://github.com/open-metadata/OpenMetadata/pull/29266): Fixes glossary term move operations by skipping unnecessary consolidation.
+- **Preserve domains through CSV import/export** [#29509](https://github.com/open-metadata/OpenMetadata/pull/29509): Glossary term domains are now preserved during CSV bulk import/export, and a `domains` column is added to the CSV format.
+- **Show approve/reject buttons after Expand All** [#29295](https://github.com/open-metadata/OpenMetadata/pull/29295): The Expand-All tree fetch now requests the `reviewers` field so nested In-Review terms retain their approve/reject buttons.
+
+### 🛡️ Data Governance & Quality
+
+- **ODPS Support for Data Products** [#29154](https://github.com/open-metadata/OpenMetadata/pull/29154): Added ODPS support for data products with custom intake forms.
+- **Data product support in Observability** [#28713](https://github.com/open-metadata/OpenMetadata/pull/28713): Added data product support in the Observability UI and backend.
+- **Preserve data products across domain deletes** [#29137](https://github.com/open-metadata/OpenMetadata/pull/29137): When a data product's domain is changed and the original domain is hard-deleted, the stale relationship is now removed so data products are preserved.
+- **Delete orphaned test cases + guard test-definition deletion** [#29081](https://github.com/open-metadata/OpenMetadata/pull/29081): Orphaned test cases can now be hard-deleted, and test-definition deletion is guarded against missing relationships.
+- **Redeploy workflow BPMN on upgrade** [#29465](https://github.com/open-metadata/OpenMetadata/pull/29465): Workflow BPMN definitions are redeployed on upgrade so moved or renamed approvals resolve correctly.
+- **Allow bare function references in SpEL conditions** [#28946](https://github.com/open-metadata/OpenMetadata/pull/28946): Governance policy SpEL conditions now allow bare references to approved functions.
+- **Snapshot entityStatus for Data Insights** [#29313](https://github.com/open-metadata/OpenMetadata/pull/29313): Snapshots `entityStatus` so Data Insights charts can filter by lifecycle status.
+- **Project tags to DI snapshot** [#29382](https://github.com/open-metadata/OpenMetadata/pull/29382): Projects `classificationTags` and `glossaryTags` to the Data Insights snapshot.
+- **Add documentation panel to test definition form** [#29430](https://github.com/open-metadata/OpenMetadata/pull/29430): Added a documentation panel to the test definition creation form.
+
+### 🔔 Alerts & Notifications
+
+- **Match Entity FQN filter against descendants** [#28833](https://github.com/open-metadata/OpenMetadata/pull/28833): Entity FQN filters now match against both the entity and its descendants.
+- **Dedup successful change events** [#28827](https://github.com/open-metadata/OpenMetadata/pull/28827): Deduplicates successful change events to prevent Postgres `ON CONFLICT` abort errors.
+- **Observability triggers skip thread events** [#29112](https://github.com/open-metadata/OpenMetadata/pull/29112): Observability status triggers no longer fire on thread events.
+- **Owner/user name filters match dotted usernames** [#29523](https://github.com/open-metadata/OpenMetadata/pull/29523): Owner and user name filters now correctly match usernames containing a dot.
+
+### 🔐 Authentication
+
+- **OIDC/SAML self-signup persists mapped email claim** [#29227](https://github.com/open-metadata/OpenMetadata/pull/29227): Self-signup now persists the mapped email claim from OIDC/SAML.
+
+### 🧬 Lineage
+
+- **Render traced edges and nodes** [#29195](https://github.com/open-metadata/OpenMetadata/pull/29195): Lineage now visually renders traced edges and nodes.
+- **Restore edges in lineage PNG export** [#29250](https://github.com/open-metadata/OpenMetadata/pull/29250): Edges are restored after canvas re-render in the lineage PNG export.
+- **Fix PNG lineage export download** [#29362](https://github.com/open-metadata/OpenMetadata/pull/29362): Fixed PNG lineage export download and late loading spinner.
+- **Correct nodeDepth for fetched nodes** [#27477](https://github.com/open-metadata/OpenMetadata/pull/27477): Updates `nodeDepth` on fetched nodes using the base `nodeDepth`.
+- **Drop nodeDepth partitioning for ELK** [#29224](https://github.com/open-metadata/OpenMetadata/pull/29224): Dropped `nodeDepth` partitioning so ELK derives lineage layers from edges.
 
 ### ⚙️ Platform
 
 - **Re-arm audit log consumer trigger on startup** [#28821](https://github.com/open-metadata/OpenMetadata/pull/28821): The audit log consumer trigger is now re-armed on startup instead of being skipped when the Quartz job already exists, preventing silent audit event loss after restarts.
 - **Validate Flowable pool connections for DB failover** [#28835](https://github.com/open-metadata/OpenMetadata/pull/28835): Enabled MyBatis pool-ping validation (SELECT 1) on the Flowable runtime engine so connections idle past 30 seconds are validated and replaced before reuse, surviving Aurora/RDS failovers and maintenance restarts.
+- **Defer row fetch in audit logs list query** [#28851](https://github.com/open-metadata/OpenMetadata/pull/28851): Avoids a full-row scan when listing audit logs.
+- **AuditLogConsumer offset gap resilience** [#29252](https://github.com/open-metadata/OpenMetadata/pull/29252): The audit log consumer no longer skips events when `change_event.offset` gaps appear under concurrent writes.
+- **Concatenate multi-line SSE data fields** [#28945](https://github.com/open-metadata/OpenMetadata/pull/28945): Multi-line SSE `data:` fields are now concatenated instead of overwritten.
+- **Force UTF-8 decoding in SSE** [#29532](https://github.com/open-metadata/OpenMetadata/pull/29532): Forces UTF-8 decoding in SSE streams to prevent JSON truncation on multibyte characters.
+- **Persist nested column changes on PATCH** [#28837](https://github.com/open-metadata/OpenMetadata/pull/28837): Nested column changes are now persisted on optimistic-locking PATCH operations.
+- **Sync IngestionPipeline schedule on app changes** [#28702](https://github.com/open-metadata/OpenMetadata/pull/28702): When an app's schedule changes, the backing `IngestionPipeline.scheduleInterval` is now synced so K8s/Argo/Hybrid runners pick up the new schedule.
+- **Support double-quotes in FQN** [#28697](https://github.com/open-metadata/OpenMetadata/pull/28697): Fully qualified names now support double-quoted segments, with guard and repair logic for corrupt FQNs.
+- **Surface external secret read failures** [#28767](https://github.com/open-metadata/OpenMetadata/pull/28767): External secret read failures are now surfaced instead of being misrouted to create.
+- **Fix SocketAddressFilter NPE** [#29263](https://github.com/open-metadata/OpenMetadata/pull/29263): Fixed NPE on WebSocket handshake without a query string.
+- **Fix RDF Fuseki bulk write timeouts** [#28564](https://github.com/open-metadata/OpenMetadata/pull/28564): Fixed bulk write timeouts in the RDF Fuseki integration.
+- **RDF: index additional entity types** [#29327](https://github.com/open-metadata/OpenMetadata/pull/29327): Dashboard, DashboardDataModel, Table, and StoredProcedure are now properly indexed in the knowledge graph.
+- **RDF glossary term filtering** [#29368](https://github.com/open-metadata/OpenMetadata/pull/29368): Added support for RDF glossary term filtering.
+- **Slow Data Retention cleanup fix** [#29363](https://github.com/open-metadata/OpenMetadata/pull/29363): Fixed slow, memory-bound Data Retention entity relationship cleanup.
+- **Backfill pipeline service edges** [#29529](https://github.com/open-metadata/OpenMetadata/pull/29529): Migration backfills pipeline service edges in 1.13.1.
+- **Disabled new sidebar items by default for existing personas** [#29032](https://github.com/open-metadata/OpenMetadata/pull/29032): New sidebar items are disabled by default for existing personas to avoid unexpected navigation changes.
+- **Remove content/column name split for classification** [#29203](https://github.com/open-metadata/OpenMetadata/pull/29203): Removed the content/column name split for classification processing.
 
 ### 🎛️ UI
 
 - **White-label brand name support** [#28624](https://github.com/open-metadata/OpenMetadata/pull/28624) [#28815](https://github.com/open-metadata/OpenMetadata/pull/28815): Replaced hardcoded "OpenMetadata" display strings with a configurable `BRAND_NAME` environment variable across all locale files and UI components, enabling downstream forks and OEMs to white-label the product name without code changes.
+- **Prevent ontology graph crash on large glossaries** [#29270](https://github.com/open-metadata/OpenMetadata/pull/29270): Prevented the ontology relations graph from crashing on large glossaries.
+- **Block-editor link modal in drawers** [#29374](https://github.com/open-metadata/OpenMetadata/pull/29374): Kept the link modal usable inside focus-trapping drawers.
+- **Preserve Persona navigation ordering** [#29353](https://github.com/open-metadata/OpenMetadata/pull/29353): Saved Persona navigation ordering is now preserved on reload.
+- **Scope "between" operator to numeric custom properties** [#29335](https://github.com/open-metadata/OpenMetadata/pull/29335): The `between` operator now correctly sends the upper bound for numeric custom properties only.
+- **Tag column filter on nested tables** [#29075](https://github.com/open-metadata/OpenMetadata/pull/29075): Tag column filter on nested schema/column tables now shows only matching fields.
+- **Hide disabled Tiers from dropdown** [#29466](https://github.com/open-metadata/OpenMetadata/pull/29466): Disabled Tiers are now hidden from the Tier selection dropdown.
+- **Data product filter in Data Quality** [#29456](https://github.com/open-metadata/OpenMetadata/pull/29456): Included data product filter in Data Quality parameters.
+- **Data Quality pagination** [#29512](https://github.com/open-metadata/OpenMetadata/pull/29512): Forwarded `showPagination` to the DataQualityTab component.
+- **FQN double-quote support in UI** [#28697](https://github.com/open-metadata/OpenMetadata/pull/28697): Added double-quoted name support in the UI FQN utility.
+- **Untitled-UI dropdowns for Add Assets drawer** [#29168](https://github.com/open-metadata/OpenMetadata/pull/29168): Replaced quick-filters in the Add Assets drawer with Untitled-UI dropdowns.

--- a/content/product-updates/v1.13.1.md
+++ b/content/product-updates/v1.13.1.md
@@ -1,0 +1,38 @@
+---
+id: 117
+version: v1.13.1
+date: Released on 27th June 2026.
+---
+
+## Changelog
+
+OpenMetadata 1.13.1 is a maintenance release focused on MCP tool reliability, search improvements, and platform stability.
+
+### 🤖 MCP (Model Context Protocol)
+
+- **MCP Registry publishing** [#27982](https://github.com/open-metadata/OpenMetadata/pull/27982): Added `server.json` for publishing openmetadata-mcp to the official MCP Registry, enabling discovery across aggregators like PulseMCP.
+- **MCP tool usage analytics** [#28352](https://github.com/open-metadata/OpenMetadata/pull/28352): MCP tool calls now track usage metrics including per-tool latency percentiles, ok/fail counts, and client classification (VS Code, Claude CLI, etc.) with reservoir sampling.
+- **Cap search_metadata response size** [#28383](https://github.com/open-metadata/OpenMetadata/pull/28383): Capped `search_metadata` response size to prevent LLM context overflow and guides LLM clients to use smaller page sizes.
+- **Map MCP error responses to correct HTTP status codes** [#28622](https://github.com/open-metadata/OpenMetadata/pull/28622): MCP tool error responses now return the correct HTTP status codes instead of generic errors.
+- **Slim get_entity_lineage payload** [#28618](https://github.com/open-metadata/OpenMetadata/pull/28618): Optimized `get_entity_lineage` MCP tool payload with a slim transform to reduce response size.
+- **Compact create tool responses** [#28633](https://github.com/open-metadata/OpenMetadata/pull/28633): `create_metric`, `create_test_case`, and `create_glossary_term` tools now return compact entity representations.
+- **Slim root_cause_analysis payload** [#28632](https://github.com/open-metadata/OpenMetadata/pull/28632): Slimmed the `root_cause_analysis` tool payload to fit within LLM context limits.
+- **Return similarityScore in search_metadata** [#28512](https://github.com/open-metadata/OpenMetadata/pull/28512): `search_metadata` results now include `_score` as `similarityScore` for relevance ranking.
+- **Fix entityType filtering in search_metadata** [#28698](https://github.com/open-metadata/OpenMetadata/pull/28698): Resolved index routing by `entityType` to prevent cross-type result leaks and hardened parameter validation.
+- **Search test cases and test suites via search_metadata** [#28743](https://github.com/open-metadata/OpenMetadata/pull/28743): `search_metadata` now supports searching test cases and test suites.
+- **Shared trim util and global response size-budget** [#28764](https://github.com/open-metadata/OpenMetadata/pull/28764): Introduced shared response-trim utilities and a global size-budget net across all MCP tools.
+- **Trim wide-table payload in get_entity_details** [#28776](https://github.com/open-metadata/OpenMetadata/pull/28776): `get_entity_details` now trims wide-table payloads (column descriptions, schema/model SQL) to stay within size budgets.
+
+### 🔍 Search
+
+- **Vectorize testSuite/testCase for hybrid search** [#28669](https://github.com/open-metadata/OpenMetadata/pull/28669): Test suites and test cases are now vectorized, enabling hybrid (keyword + semantic) search over data quality entities.
+- **Make users and admins searchable by email** [#28800](https://github.com/open-metadata/OpenMetadata/pull/28800): Users and admins are now searchable by their email address.
+
+### ⚙️ Platform
+
+- **Re-arm audit log consumer trigger on startup** [#28821](https://github.com/open-metadata/OpenMetadata/pull/28821): The audit log consumer trigger is now re-armed on startup instead of being skipped when the Quartz job already exists, preventing silent audit event loss after restarts.
+- **Validate Flowable pool connections for DB failover** [#28835](https://github.com/open-metadata/OpenMetadata/pull/28835): Enabled MyBatis pool-ping validation (SELECT 1) on the Flowable runtime engine so connections idle past 30 seconds are validated and replaced before reuse, surviving Aurora/RDS failovers and maintenance restarts.
+
+### 🎛️ UI
+
+- **White-label brand name support** [#28624](https://github.com/open-metadata/OpenMetadata/pull/28624) [#28815](https://github.com/open-metadata/OpenMetadata/pull/28815): Replaced hardcoded "OpenMetadata" display strings with a configurable `BRAND_NAME` environment variable across all locale files and UI components, enabling downstream forks and OEMs to white-label the product name without code changes.

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "v1.13.1",
+    "date": "Released on 27th June 2026.",
+    "hasFeatures": false
+  },
+  {
     "version": "v1.13.0",
     "date": "Released on 8th June 2026.",
     "hasFeatures": true


### PR DESCRIPTION
## Summary

- Adds release notes for OpenMetadata v1.13.1 (`content/product-updates/v1.13.1.md`)
- Adds v1.13.1 entry to `content/product-updates/versions.json`

This is a maintenance release covering MCP tool reliability improvements (payload trimming, usage analytics, registry publishing, search fixes), hybrid search vectorization for test suites/cases, user email search, audit log and Flowable connection pool fixes, and white-label brand name support in the UI.

## Test plan

- [ ] Verify release notes page renders correctly at `/product-updates#v1.13.1`
- [ ] Verify version appears in the version selector/list
- [ ] Verify all PR links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)