### PR TITLE
styles: add .md-link class for Learning Center inline cross-links

### DIFF
--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -440,6 +440,18 @@ a:hover {
   color: #004ec2;
 }
 
+/* .md-link is used by inline cross-links in Learning Center article bodies
+   (e.g. "This is part of a series of articles about <a className="md-link">metadata management</a>").
+   Convention borrowed from getcollate LC; adding here so OMD LC renders the same. */
+.md-link {
+  color: #0061f2;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.md-link:hover {
+  color: #004ec2;
+}
+
 a:not([href]):not([class]),
 a:not([href]):not([class]):hover {
   color: inherit;


### PR DESCRIPTION
## Summary

Adds the \`.md-link\` CSS class to the site stylesheet. This class is used by inline cross-links inside Learning Center article bodies (e.g. \`This is part of a series of articles about <a className="md-link">metadata management</a>\`).

## Why

The \`.md-link\` convention was borrowed from the getcollate Learning Center. On getcollate, \`.md-link\` is defined and inline body cross-links render with a visible blue color and underline. On OMD, the class was applied but never defined, so those cross-links render invisible until hover.

## Affected content

Currently 4 shipped LC articles use \`md-link\` and are blocked on this CSS being present:

| Article | \`md-link\` usages |
|---|---|
| \`metadata-management.md\` | 8 |
| \`metadata-search.md\` | 1 |
| \`metadata-automation.md\` | 1 |
| \`metadata-services.md\` | 1 |

## Diff

12-line CSS addition in \`src/styles/styles.css\` next to the existing base \`a\` rules:

\`\`\`css
.md-link {
  color: #0061f2;                 /* Matches base anchor color */
  text-decoration: underline;     /* Underline for body-inline visibility */
  text-underline-offset: 2px;
}
.md-link:hover {
  color: #004ec2;
}
\`\`\`

## Test plan
- [ ] Netlify preview renders \`This is part of a series of articles about <a>metadata management</a>\` as a visible blue underlined link on \`/learning-center/metadata-search\` (or any other LC article with an \`md-link\`)
- [ ] Hover state deepens the color as expected
- [ ] Base anchor styling (e.g., nav links) is unaffected