### PR TITLE
Remove Summit '26 announcement banner from site layout

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "next/router";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
@@ -12,7 +11,6 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <div className="mx-auto fixed top-0 w-full z-[1030]">
-        <SummitBanner />
         <NavbarDev onClick={handleTryOpenMetadataClick} />
       </div>
       {children}


### PR DESCRIPTION
## Summary

Remove the Summit '26 top announcement banner (thin strip above the nav: "OpenMetadata production stories from OpenAI, Yelp, Rakuten & more … Learn More 🚀"). The event has passed.

## What's included

- `src/components/Layout/Layout.tsx` — removed `<SummitBanner />` (the `NavbarDev/SummitBanner.component`) and its import

Note: this is the thin top strip only. The larger `SummitBanner` homepage blade (in `src/pages/index.tsx`, `components/SummitBanner/SummitBanner`) is a separate element and is left untouched — let me know if that should go too.

## Test plan

- [ ] Netlify preview: no announcement strip above the navbar
- [ ] Fixed header height/spacing still correct (no gap under nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)