### PR TITLE
chore: add release notes for 1.12.14

### DIFF
--- a/content/product-updates/v1.12.14.md
+++ b/content/product-updates/v1.12.14.md
@@ -1,0 +1,39 @@
+---
+id: 118
+version: v1.12.14
+date: Released on 28th July 2026.
+---
+
+# OpenMetadata 1.12.14
+
+**Release Date**: 28th July 2026
+
+View the [OpenMetadata 1.12.14 GitHub release](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.14-release).
+
+## Changelog
+
+### 🔒 Security
+
+- **Patch MLflow authorization vulnerabilities** [#30046](https://github.com/open-metadata/OpenMetadata/pull/30046): Raised the `mlflow-skinny` requirement to a patched 3.13 or newer release to address CVE-2026-2635 and CVE-2026-8147.
+- **Patch PyArrow IPC vulnerabilities** [#30146](https://github.com/open-metadata/OpenMetadata/pull/30146): Raised the PyArrow requirement to `>=23.0.1,<26` to address CVE-2026-25087 and CVE-2024-52338.
+- **Patch server dependency vulnerabilities** [bd31ff6](https://github.com/open-metadata/OpenMetadata/commit/bd31ff64405cb01711546bb2eb980787d348dd22) [cd46662](https://github.com/open-metadata/OpenMetadata/commit/cd46662204395f2ca7d449d4ff07ccce7da47a7d) [#30391](https://github.com/open-metadata/OpenMetadata/pull/30391): Updated Jackson, Logback, Apache HttpComponents, Apache Calcite, PostgreSQL JDBC, Netty, and Jetty to patched versions.
+- **Harden ingestion container images** [#30024](https://github.com/open-metadata/OpenMetadata/pull/30024) [#30454](https://github.com/open-metadata/OpenMetadata/pull/30454): Removed unused operating-system packages, switched to slimmer runtime components where appropriate, and installed available Debian security updates.
+- **Patch UI dependency vulnerabilities** [4ce8b3a](https://github.com/open-metadata/OpenMetadata/commit/4ce8b3a7d97edbe40b616df7c2404adff1d2cb77): Updated Axios, `ws`, `js-yaml`, `brace-expansion`, `fast-uri`, and related packages across both UI workspaces.
+
+### 🔍 Search & Performance
+
+- **Preserve the latest search preview ranking** [#30086](https://github.com/open-metadata/OpenMetadata/pull/30086): Search Settings now discards superseded preview responses, so an older, slower request cannot overwrite the ranking for the latest field-weight changes.
+- **Fix Test Suite reindexing failures** [#30220](https://github.com/open-metadata/OpenMetadata/pull/30220): Test Suite keyset reads now bind their pagination parameters correctly, preventing reindexing from failing with a missing named-parameter error.
+
+### 🛡️ Data Governance & Quality
+
+- **Keep Test Suite results aligned with the latest selection** [#29561](https://github.com/open-metadata/OpenMetadata/pull/29561): The Data Quality Test Suites page now ignores stale responses when users switch tabs, pages, searches, or owner filters quickly.
+
+### ⚙️ Apps & Ingestion
+
+- **Fix Data Retention relationship cleanup** [#29981](https://github.com/open-metadata/OpenMetadata/pull/29981): Relationship cleanup now reads `relationType` from the relationship JSON, preventing partial-failure errors on PostgreSQL and MySQL.
+- **Fix MySQL ingestion image builds** [#30264](https://github.com/open-metadata/OpenMetadata/pull/30264): Added `pkg-config` to the ingestion base images so `mysqlclient` can build successfully.
+
+### 🧬 Lineage
+
+- **Fix lineage PNG downloads and loading feedback** [#29362](https://github.com/open-metadata/OpenMetadata/pull/29362): PNG exports now use a browser-compatible download flow, display the loading indicator before rendering begins, and allow more time for large lineage graphs.

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "v1.12.14",
+    "date": "Released on 28th July 2026.",
+    "hasFeatures": false
+  },
+  {
     "version": "v1.12.13",
     "date": "Released on 6th July 2026.",
     "hasFeatures": false


### PR DESCRIPTION
## Summary

- add the OpenMetadata 1.12.14 product update with OM-only changes
- add v1.12.14 to the product-update version index
- follow the structure used for the 1.12.13 release notes

## Validation

- `npm run build`
- `git diff --check`
- verified release and changelog links