### PR TITLE
chore: add release notes for 1.13.2

### DIFF
--- a/content/product-updates/v1.13.2.md
+++ b/content/product-updates/v1.13.2.md
@@ -1,0 +1,137 @@
+---
+id: 119
+version: v1.13.2
+date: Released on 30th July 2026.
+---
+
+
+## Changelog
+
+OpenMetadata 1.13.2 is a maintenance release delivering MCP tool enhancements, search and reindexing reliability fixes, security patches, connector improvements, data governance and quality updates, lineage fixes, and UI enhancements.
+
+### 🔒 Security
+
+- **Jackson, Logback, Postgres & Calcite dependency pins** [#30396](https://github.com/open-metadata/OpenMetadata/pull/30396): Aligned Jackson, Logback, Postgres, and Calcite dependency pins with main to clear Inspector high findings.
+- **Log4j CVE-2026-49844** [#30311](https://github.com/open-metadata/OpenMetadata/pull/30311): Bumped `log4j` from 2.25.4 to 2.25.5 to patch CVE-2026-49844.
+- **Trivy ingestion image CVEs** [#30516](https://github.com/open-metadata/OpenMetadata/pull/30516): Resolved Trivy-flagged CVEs by upgrading Airflow to 3.2.2, updating Spark Hive jars, and patching perl/nss packages.
+- **Trim vulnerable apt packages from ingestion Docker images** [#30024](https://github.com/open-metadata/OpenMetadata/pull/30024) [#30454](https://github.com/open-metadata/OpenMetadata/pull/30454): Removed CVE-flagged apt packages from ingestion Docker base images and hardened apt-get security.
+- **PyArrow IPC use-after-free CVEs** [#30146](https://github.com/open-metadata/OpenMetadata/pull/30146): Bumped `pyarrow` past the IPC use-after-free CVEs.
+- **mlflow-skinny Snyk findings** [#30046](https://github.com/open-metadata/OpenMetadata/pull/30046): Bumped `mlflow-skinny` to clear critical/high Snyk findings.
+- **Ingestion dependency CVE bumps** [#30034](https://github.com/open-metadata/OpenMetadata/pull/30034): Bumped 6 CVE-flagged ingestion dependencies to patched versions.
+- **No reviewer authz shortcut on CREATE** [#30026](https://github.com/open-metadata/OpenMetadata/pull/30026): Fixed a security gap where reviewer authorization shortcut was incorrectly granted on entity CREATE operations.
+- **Stop exposing app bot JWT and private secrets** [#29793](https://github.com/open-metadata/OpenMetadata/pull/29793): App bot JWT tokens and `privateConfiguration` secrets are no longer exposed in API responses.
+
+### 🤖 MCP (Model Context Protocol)
+
+- **New `get_user_context` tool** [#30384](https://github.com/open-metadata/OpenMetadata/pull/30384): Added a `get_user_context` MCP tool that returns the calling user's profile, roles, and team memberships for context-aware AI interactions.
+- **Tool metadata annotations** [#30105](https://github.com/open-metadata/OpenMetadata/pull/30105): MCP tools are now annotated with `title`, `readOnly`, `destructive`, and `openWorld` hints to help LLM clients make safer tool-selection decisions.
+- **Unified read-tool pagination with `nextCursor`** [#29800](https://github.com/open-metadata/OpenMetadata/pull/29800): All MCP read tools now share a unified opaque `nextCursor` pagination contract, replacing ad-hoc page parameters for consistent multi-page traversal.
+- **Structured content and soft-error signaling** [#29799](https://github.com/open-metadata/OpenMetadata/pull/29799): MCP tools now emit `structuredContent` alongside text and flag non-fatal issues via `isError` for better LLM error handling.
+- **Read-tool size cap via item paging** [#29732](https://github.com/open-metadata/OpenMetadata/pull/29732): Read tools now page items rather than truncate content when a response approaches the size cap, ensuring no data is silently dropped.
+- **Paginate `get_entity_details` columns** [#29707](https://github.com/open-metadata/OpenMetadata/pull/29707) [#29713](https://github.com/open-metadata/OpenMetadata/pull/29713): `get_entity_details` now paginates column lists for wide entities to stay within LLM context limits.
+- **Authorize `get_entity_details` against resolved entity** [#30011](https://github.com/open-metadata/OpenMetadata/pull/30011) [#30043](https://github.com/open-metadata/OpenMetadata/pull/30043): Fixed `get_entity_details` to perform authorization checks against the fully resolved entity, preventing unauthorized access via FQN aliases.
+
+### 🔍 Search & Reindexing
+
+- **Migrate stale owner aggregation field** [#29691](https://github.com/open-metadata/OpenMetadata/pull/29691): A 1.13.2 migration corrects stale owner aggregation field references in stored search settings to prevent broken search filters after upgrade.
+- **Column bulk operations search at scale** [#29695](https://github.com/open-metadata/OpenMetadata/pull/29695): Fixed column bulk operations search returning no results on large datasets.
+- **Index `testSuite` on tables during selective reindex** [#29688](https://github.com/open-metadata/OpenMetadata/pull/29688): Selective reindex now includes `testSuite` associations on table documents.
+- **Durable realtime column indexing** [#29653](https://github.com/open-metadata/OpenMetadata/pull/29653): Realtime column index updates now await the bulk write to complete before acknowledging, preventing silent index lag.
+- **Index all body chunks for semantic retrieval** [#29850](https://github.com/open-metadata/OpenMetadata/pull/29850): All body text chunks are now indexed for semantic retrieval, fixing incomplete hybrid search results.
+- **ES/OS document rejection hardening** [#28671](https://github.com/open-metadata/OpenMetadata/pull/28671): Engine-native mapping hardening prevents Elasticsearch/OpenSearch from rejecting index documents due to type mismatches.
+- **Index domain parent for sub-domain counts** [#29118](https://github.com/open-metadata/OpenMetadata/pull/29118): Domain parent is now indexed so the Sub Domains tab correctly counts child domains after a full reindex.
+- **`mlModelService` search index routing fix** [#30574](https://github.com/open-metadata/OpenMetadata/pull/30574): Fixed `search index=mlModelService` incorrectly returning ML Model assets from other indexes.
+- **Promote every staged index in distributed reindex** [#30519](https://github.com/open-metadata/OpenMetadata/pull/30519): All staged indexes are now promoted atomically in a distributed reindex, preventing partial promotion failures.
+- **`customPropertiesTyped` nested mapping** [#30501](https://github.com/open-metadata/OpenMetadata/pull/30501): Added missing nested `customPropertiesTyped` field mapping to 5 entity indexes to enable custom property aggregations in search.
+- **Restore dropped table reindex fields** [#30177](https://github.com/open-metadata/OpenMetadata/pull/30177): Restored `schemaDefinition` and ER diagram fields that were inadvertently dropped from the table search index in 1.13.
+- **Populate service for stored procedures on reindex** [#30127](https://github.com/open-metadata/OpenMetadata/pull/30127): The service field is now correctly populated for stored procedures during reindex.
+- **Preserve search preview ranking order** [#30083](https://github.com/open-metadata/OpenMetadata/pull/30083): Search preview results now preserve the intended best-match ranking order across all hit pages.
+- **Unwedge reindex orchestrator on crash** [#28699](https://github.com/open-metadata/OpenMetadata/pull/28699): The reindex orchestrator now recovers from a crash by unwedging itself and cleaning up stale Quartz jobs.
+- **Stop falsely abandoning healthy reindex jobs** [#29547](https://github.com/open-metadata/OpenMetadata/pull/29547): Fixed the orchestrator incorrectly abandoning reindex jobs that hold a live lock, causing premature failure.
+- **Remove DB-backed search index mapping settings** [#30218](https://github.com/open-metadata/OpenMetadata/pull/30218): Removed the legacy database-backed search index mapping settings page and its UI entry, simplifying search configuration.
+- **Search cluster fitness diagnostic** [#28447](https://github.com/open-metadata/OpenMetadata/pull/28447): Added a REST endpoint and ops CLI command for diagnosing search cluster fitness (shard health, index sizes, replication lag).
+- **Resilient embeddings and reindex auto-tune** [#29833](https://github.com/open-metadata/OpenMetadata/pull/29833): Search embedding generation, reindex auto-tuning, and audit log export now recover gracefully on any pod size rather than failing the entire run.
+- **Bind BoundedListFilter params in TestSuite reads** [#30219](https://github.com/open-metadata/OpenMetadata/pull/30219): Fixed unbound query parameters in TestSuite keyset pagination that could cause full-table scans.
+- **Self-heal custom-property registry on cache miss** [#30044](https://github.com/open-metadata/OpenMetadata/pull/30044): Custom-property type registry now self-heals on a cache miss across replicas instead of returning stale type mappings.
+
+### 🔌 Connectors & Ingestion
+
+- **Kafka Connect: EventRouter/RegexRouter lineage** [#29980](https://github.com/open-metadata/OpenMetadata/pull/29980): Kafka Connect now generates lineage for topics routed via `EventRouter` and `RegexRouter` SMTs.
+- **dbt Cloud: column-level lineage from compiled SQL** [#29731](https://github.com/open-metadata/OpenMetadata/pull/29731): dbt Cloud connector now extracts column-level lineage directly from compiled SQL in addition to the manifest.
+- **Databricks partner User-Agent** [#30222](https://github.com/open-metadata/OpenMetadata/pull/30222): Set the Databricks partner User-Agent header for telemetry attribution in Databricks ingestion.
+- **OpenLineage: Glue symlink & multi-catalog dataset lineage** [#30272](https://github.com/open-metadata/OpenMetadata/pull/30272): Resolved OpenLineage lineage for Glue symlink tables and multi-catalog datasets that previously failed FQN resolution.
+- **ADLS: respect `bucketName` during container discovery** [#30271](https://github.com/open-metadata/OpenMetadata/pull/30271): Azure Data Lake Storage ingestion now respects the configured `bucketName` filter during container discovery.
+- **Redshift Spectrum: map Hive types** [#29910](https://github.com/open-metadata/OpenMetadata/pull/29910): Redshift Spectrum now maps Hive-compatible types (`string`, `double`, `char`, `tinyint`) instead of reporting `UNKNOWN`.
+- **Delta Lake: parse struct field names with colons** [#30080](https://github.com/open-metadata/OpenMetadata/pull/30080): Fixed Delta Lake schema parser to correctly handle struct field names containing colons.
+- **MSSQL: BigInteger identity reflection on SQLAlchemy 2.0** [#29639](https://github.com/open-metadata/OpenMetadata/pull/29639): Fixed MSSQL `BigInteger` identity column reflection under SQLAlchemy 2.0.
+- **MSSQL: Query Store for lineage & usage** [#29719](https://github.com/open-metadata/OpenMetadata/pull/29719): MSSQL query and stored-procedure lineage and usage now use the Query Store for improved reliability, with hardened fault-tolerance and warnings on query-log truncation.
+- **BigQuery: GCP service account impersonation** [#29683](https://github.com/open-metadata/OpenMetadata/pull/29683): Fixed GCP service account impersonation across BigQuery ADC and SQLAlchemy paths.
+- **Ingestion engines: AUTOCOMMIT to release AccessShareLock** [#29658](https://github.com/open-metadata/OpenMetadata/pull/29658): Ingestion engines now use AUTOCOMMIT mode to release `AccessShareLock` promptly, preventing lock buildup on busy PostgreSQL instances.
+- **Data quality: use sample config for sample data ingestion** [#29907](https://github.com/open-metadata/OpenMetadata/pull/29907): Data quality sample data ingestion now uses the correct sample configuration instead of the full profiler config.
+- **Add `pkg-config` to ingestion-base images** [#30264](https://github.com/open-metadata/OpenMetadata/pull/30264): Added `pkg-config` to ingestion-base Docker images so `mysqlclient` compiles correctly from source.
+- **Oracle: preserve CTAS `sqlQuery` on lineage patch** [#29646](https://github.com/open-metadata/OpenMetadata/pull/29646): Oracle connector now preserves the `sqlQuery` on CTAS lineage patches and correctly parses stored procedure names.
+- **dbt: populate `TestCaseResult.result` with test message** [#29650](https://github.com/open-metadata/OpenMetadata/pull/29650): `TestCaseResult.result` is now populated with the dbt test failure message for better observability.
+- **Lineage: dedup queries and treat conflicts as warnings** [#28757](https://github.com/open-metadata/OpenMetadata/pull/28757): Duplicate lineage queries are deduplicated and already-present query conflicts are now logged as warnings instead of errors.
+
+### 📖 Glossary
+
+- **Parse glossary CSV `entityStatus` case-insensitively** [#29510](https://github.com/open-metadata/OpenMetadata/issues/29510): Glossary CSV bulk import now accepts `entityStatus` values in any case (e.g., `DRAFT`, `Draft`, `draft`).
+- **Paginate glossary term relation settings** [#30372](https://github.com/open-metadata/OpenMetadata/pull/30372): The glossary term relation settings page is now paginated to prevent timeouts on glossaries with many related terms.
+
+### 🛡️ Data Governance & Quality
+
+- **Validate DI chart formulas via formula evaluator** [#30073](https://github.com/open-metadata/OpenMetadata/pull/30073): Data Insights chart formula validation now uses `DataInsightFormulaEvaluator` instead of the policy validator to correctly flag invalid formulas.
+- **Return 400 for chart metrics with no function or formula** [#29890](https://github.com/open-metadata/OpenMetadata/pull/29890): Data Insights chart preview returns HTTP 400 (not 500) when a chart metric is missing both a function and a formula.
+- **Custom property filter and aggregation in Data Insights** [#29643](https://github.com/open-metadata/OpenMetadata/pull/29643): Data Insights charts now support filtering and grouping by custom properties.
+- **Mark superseded approval runs as SUPERSEDED** [#29868](https://github.com/open-metadata/OpenMetadata/pull/29868): When a new approval workflow supersedes a running one, the previous run is now marked as `SUPERSEDED` instead of `FAILURE`.
+- **Data Contract: fix NOT_IN JsonLogic multivalue fields** [#29003](https://github.com/open-metadata/OpenMetadata/pull/29003): Data Contract `NOT_IN` operator now emits correct JsonLogic multivalue field expressions.
+- **Fix `Table.schemaDefinition` silently dropped on PUT** [#29441](https://github.com/open-metadata/OpenMetadata/pull/29441): `Table.schemaDefinition` is no longer silently dropped when a full PUT update is performed.
+- **Preserve `autoClassificationConfig` on classification PUT** [#29735](https://github.com/open-metadata/OpenMetadata/pull/29735): A classification `PUT` now preserves the existing `autoClassificationConfig` instead of resetting it.
+- **Data Contract alert filter search** [#30007](https://github.com/open-metadata/OpenMetadata/pull/30007): Fixed broken search on the Data Contract alert filter panel.
+- **Auto-classification: break sibling-tag score ties** [#29989](https://github.com/open-metadata/OpenMetadata/pull/29989): Auto-classification now breaks ties between sibling tags using a deterministic secondary sort to prevent unstable classification results.
+
+### 🧬 Lineage
+
+- **Fix `fitView` not centering the lineage DAG** [#30163](https://github.com/open-metadata/OpenMetadata/pull/30163): The `fitView` call on lineage page load now correctly centers the DAG in the viewport.
+- **Render query-lineage SQL on the edge drawer** [#29651](https://github.com/open-metadata/OpenMetadata/pull/29651): The lineage edge drawer now renders the underlying SQL query for query-level lineage edges.
+
+### ⚙️ Platform
+
+- **Content-based ETag to prevent stale votes/followers** [#30497](https://github.com/open-metadata/OpenMetadata/pull/30497): ETags are now computed from entity content rather than version, preventing browsers from serving stale votes and follower counts via 304 responses.
+- **Harden entity pagination, multi-owner authz, and cursor charset** [#29750](https://github.com/open-metadata/OpenMetadata/pull/29750): Hardened keyset pagination, enforced authorization checks for multi-owner assignments, and fixed cursor encoding for non-ASCII entity names.
+- **Paginate `GET /v1/events` to prevent Java heap OOM** [#29958](https://github.com/open-metadata/OpenMetadata/pull/29958): The events endpoint now supports cursor-based pagination with an optional `endTs` bound to prevent out-of-memory errors on large event backlogs.
+- **Avoid Out-of-sort-memory on entity list pagination** [#29898](https://github.com/open-metadata/OpenMetadata/pull/29898): Entity list queries no longer trigger MySQL's `Out of sort memory` error on large tables by switching to indexed keyset pagination.
+- **Prevent circular team hierarchy** [#30063](https://github.com/open-metadata/OpenMetadata/pull/30063): Team create and update operations now validate for circular parent-child references and reject them with a 400 error.
+- **Reclaim orphaned ingestion pipelines** [#30030](https://github.com/open-metadata/OpenMetadata/pull/30030): A migration backport reclaims ingestion pipelines that became orphaned due to partial deletes.
+- **Enable impersonation for custom bots with RBAC** [#29029](https://github.com/open-metadata/OpenMetadata/pull/29029): Custom bots can now use service account impersonation with RBAC-scoped control for fine-grained delegation.
+- **Preserve inherited domains in CSV bulk edit** [#30013](https://github.com/open-metadata/OpenMetadata/pull/30013): Bulk CSV edit now preserves inherited domain assignments instead of clearing them when a domain column is absent.
+- **Compare email domains case-insensitively** [#30285](https://github.com/open-metadata/OpenMetadata/pull/30285): Principal domain enforcement now compares email domains case-insensitively, fixing login failures for users with mixed-case email domains.
+- **Validate legacy feed task payloads** [#29582](https://github.com/open-metadata/OpenMetadata/pull/29582): Legacy feed task payloads are now validated before processing to prevent ingestion pipeline failures on malformed historical records.
+- **Expose `Trigger` in ingestionPipeline descriptor** [#29530](https://github.com/open-metadata/OpenMetadata/pull/29530): The ingestion pipeline `Trigger` field is now exposed in the pipeline descriptor, and `EditAll` permission is required to kill a running pipeline.
+- **Bypass domain enforcement for OM-internally-issued tokens** [#29433](https://github.com/open-metadata/OpenMetadata/pull/29433): Service and bot tokens issued by OpenMetadata itself now bypass principal domain enforcement to prevent breakage during startup and migrations.
+- **Cap Titan Bedrock embedding input** [#30021](https://github.com/open-metadata/OpenMetadata/pull/30021): Input to Titan Bedrock embedding models is now capped to avoid `ValidationException` on oversized payloads.
+- **Retry Bedrock 429 throttling with backoff** [#29938](https://github.com/open-metadata/OpenMetadata/pull/29938): Bedrock API calls now retry on HTTP 429 (Too Many Requests) with exponential backoff.
+- **Fix missing `ownerName` field** [#29899](https://github.com/open-metadata/OpenMetadata/pull/29899): Restored the `ownerName` field that was missing from entity responses after a prior refactor.
+- **RDF: exclude unsupported entity types** [#29381](https://github.com/open-metadata/OpenMetadata/pull/29381): Entity types not supported by the RDF knowledge graph are now excluded at index time to prevent serialization errors.
+- **Record failed webhook events on non-2xx delivery** [#29808](https://github.com/open-metadata/OpenMetadata/pull/29808): Event subscription delivery failures are now recorded when the webhook returns any non-2xx status code, not just network errors.
+- **Default pipeline patch version when `z` component is missing** [#29787](https://github.com/open-metadata/OpenMetadata/pull/29787): Pipeline version patching now defaults the `z` component to 0 when it is absent, preventing `NullPointerException` on version-less pipelines.
+- **Fix stale description source badge** [#29843](https://github.com/open-metadata/OpenMetadata/pull/29843): Clearing a nested field's description no longer leaves a stale source badge in the UI.
+- **Bound memory in bulk recursive hard delete** [#29322](https://github.com/open-metadata/OpenMetadata/pull/29322): Bulk recursive hard delete now bounds memory usage and skips work already covered by ancestor deletes to prevent OOM on large hierarchies.
+- **Backport orphaned column-doc cleanup** [#29549](https://github.com/open-metadata/OpenMetadata/pull/29549): Orphaned column documentation entries from deleted columns are now cleaned up during migration.
+
+### 🎛️ UI
+
+- **Multi-owner avatar stack with hover popover** [#29612](https://github.com/open-metadata/OpenMetadata/pull/29612): Entity header now stacks multiple owner avatars with a hover popover showing all owners, replacing a truncated list.
+- **Migrate service icons from PNG to WebP** [#29105](https://github.com/open-metadata/OpenMetadata/pull/29105): All service connector icons have been migrated from PNG to WebP for faster page loads and better visual quality.
+- **`PaginationCardWithControls` component** [#30379](https://github.com/open-metadata/OpenMetadata/pull/30379): Backported the `PaginationCardWithControls` component to 1.13 for consistent paginated card layouts.
+- **Fix `is_not_set` semantics for Owner/Domain/DataProduct filters** [#30439](https://github.com/open-metadata/OpenMetadata/pull/30439): Corrected the `is_not_set` filter semantics for Owner, Domain, and Data Product fields in the Explore page filters.
+- **Table version page shows historical columns** [#29411](https://github.com/open-metadata/OpenMetadata/pull/29411): The table version history page now correctly shows the column state at that version instead of the current live API columns.
+- **Handle test suite tab loading race** [#29561](https://github.com/open-metadata/OpenMetadata/pull/29561): Fixed a race condition that could leave the test suite tab in a perpetual loading state.
+- **Hide data product lifecycle stage badge** [#29290](https://github.com/open-metadata/OpenMetadata/pull/29290): The lifecycle stage badge is now hidden on data product pages where it is not applicable.
+- **Lazy loading for enum select in advanced search** [#29736](https://github.com/open-metadata/OpenMetadata/pull/29736): Enum select fields in the advanced search query builder now load options lazily to prevent UI freezes on large enumerations.
+- **Column tag filtering in advanced search** [#28871](https://github.com/open-metadata/OpenMetadata/pull/28871): Advanced search now supports filtering by column-level tags.
+- **Permissions for run/deploy buttons** [#29527](https://github.com/open-metadata/OpenMetadata/pull/29527): Run and deploy buttons on ingestion pipelines now correctly reflect the user's permissions and are disabled when the user lacks the required role.
+- **Column grid alphabetical sort** [#29751](https://github.com/open-metadata/OpenMetadata/pull/29751): Column bulk-edit grid now sorts columns alphabetically by default for easier navigation.
+- **Fix Certification icon rendering** [#29830](https://github.com/open-metadata/OpenMetadata/pull/29830): Resolved a rendering issue that caused the Certification icon to display incorrectly in entity headers.
+- **Total asset count for filtered Explore results** [#28873](https://github.com/open-metadata/OpenMetadata/pull/28873): The Explore page now shows the correct total asset count when advanced search filters are active.
+

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "v1.13.2",
+    "date": "Released on 30th July 2026.",
+    "hasFeatures": false
+  },
+  {
     "version": "v1.12.14",
     "date": "Released on 28th July 2026.",
     "hasFeatures": false


### PR DESCRIPTION
## Summary

- add the OpenMetadata 1.13.2 product update with OM-only changes
- add v1.13.2 to the product-update version index
- follow the structure used for the1.13.1 release notes

## Validation

- `npm run build`
- `git diff --check`
- verified release and changelog links