### PR TITLE
chore: add release notes for 1.13.3

### DIFF
--- a/content/product-updates/v1.13.3.md
+++ b/content/product-updates/v1.13.3.md
@@ -1,0 +1,30 @@
+---
+id: 120
+version: v1.13.3
+date: Released on 31st July 2026.
+---
+
+
+## Changelog
+
+OpenMetadata 1.13.3 is a maintenance release delivering data contract and governance workflow fixes, alert delivery fixes, a Snowflake foreign-key reflection fix, and UI fixes.
+
+### 🔌 Connectors & Ingestion
+
+- **Snowflake: foreign-key collisions across tables sharing a constraint name** [#30473](https://github.com/open-metadata/OpenMetadata/pull/30473): Foreign-key reflection is now keyed on `(fk_name, table_name)`, so cloned tables that reuse a constraint name no longer merge into a single constraint referencing another table's columns and getting rejected with `400 Invalid column name`.
+
+### 🛡️ Data Governance & Quality
+
+- **Data contracts stuck at `Running` after a Data Quality pipeline completes** [#30531](https://github.com/open-metadata/OpenMetadata/pull/30531): The `testSuite` → `dataContract` reverse relationship is now persisted on contract create/update, so contract status resolves when the pipeline finishes instead of sitting at `Running` indefinitely. Regression from 1.13.0.
+- **Sanitize poisoned governance trigger filters** [`5963637b`](https://github.com/open-metadata/OpenMetadata/commit/5963637bf54995861a015e383d7ce3792fdf8fb6): Event-based workflow trigger filters stored as an empty or placeholder value (`""`, `{}`) are now ignored instead of rejecting every event, and a 1.13.3 migration repairs affected `workflowDefinitions` rows in place.
+- **Hide soft-deleted owners on the Test Suite detail page** [#30520](https://github.com/open-metadata/OpenMetadata/pull/30520): Editing owners on a logical Test Suite no longer fails with `array item index is out of range`; `TestSuiteResource.getByName` now honours `includeRelations`, matching every other detail page.
+- **Intake form `formFields` support** [#30614](https://github.com/open-metadata/OpenMetadata/pull/30614): Added a `formFields` array with a per-field `required` flag to the `IntakeForm` schema, along with a migration that backfills it from the legacy `requiredFields`. Backend only in this release.
+
+### ⚙️ Platform
+
+- **Skip notification recipients without contact information** [#30518](https://github.com/open-metadata/OpenMetadata/pull/30518): A team or user with no email address or webhook no longer discards every other recipient of the same alert; recipients are now resolved individually, matching the webhook path.
+
+### 🎛️ UI
+
+- **Tag and Glossary dropdowns not selectable in the Column Bulk Operations edit drawer** [#30634](https://github.com/open-metadata/OpenMetadata/pull/30634): The tag and glossary dropdowns now render inside the edit drawer, so options can be selected instead of having clicks swallowed by the drawer's focus containment.
+

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "v1.13.3",
+    "date": "Released on 31st July 2026.",
+    "hasFeatures": false
+  },
+  {
     "version": "v1.13.2",
     "date": "Released on 30th July 2026.",
     "hasFeatures": false


### PR DESCRIPTION
Adds the 1.13.3 product update, following the structure of [#393](https://github.com/open-metadata/openmetadata-site/pull/393) (1.13.2).

## Changes

- **`content/product-updates/v1.13.3.md`** (new) — `id: 120`, dated 31st July 2026. Frontmatter and trailing bytes match `v1.13.2.md`.
- **`content/product-updates/versions.json`** — `v1.13.3` prepended.

## Content

Derived from `1.13.2-release...1.13.3-release` in OpenMetadata (19 commits). Seven are user-facing; the rest are Playwright/test fixes, a `CustomizePageUtils` refactor, a reverted-and-re-cherry-picked intake-forms change, and release chores.

| Area | Entry |
| --- | --- |
| Connectors & Ingestion | Snowflake FK collisions across tables sharing a constraint name ([#30473](https://github.com/open-metadata/OpenMetadata/pull/30473)) |
| Data Governance & Quality | Data contracts stuck at `Running` ([#30531](https://github.com/open-metadata/OpenMetadata/pull/30531)) · poisoned governance trigger filters ([`5963637b`](https://github.com/open-metadata/OpenMetadata/commit/5963637bf54995861a015e383d7ce3792fdf8fb6)) · soft-deleted owners on Test Suite ([#30520](https://github.com/open-metadata/OpenMetadata/pull/30520)) · intake form `formFields` ([#30614](https://github.com/open-metadata/OpenMetadata/pull/30614)) |
| Platform | Skip notification recipients without contact info ([#30518](https://github.com/open-metadata/OpenMetadata/pull/30518)) |
| UI | Tag/Glossary dropdowns in Column Bulk Operations drawer ([#30634](https://github.com/open-metadata/OpenMetadata/pull/30634)) |

Body text is identical to [docs-om#363](https://github.com/open-metadata/docs-om/pull/363).

## Notes for reviewers

- The intake-forms entry is **backend only** on this line — the UI half of [#30614](https://github.com/open-metadata/OpenMetadata/pull/30614) was reverted on 1.13 because it depends on `ui-core-components` APIs not present there. Called out in the entry text.
- The governance trigger-filter fix landed as a direct commit with no PR, so it links to the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)