### PR TITLE
Update events page feature videos to July 2026

### DIFF
--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -112,17 +112,17 @@ export default function Events() {
                   <div className="col-lg-6 mb-4">
                     <div className="card">
                       <div className="card-body">
-                        <YoutubeEmbed videoId="NxqCn-3XkVc" />
-                        <p className="font-semibold mb-0 mt-2">May 2025</p>
+                        <YoutubeEmbed videoId="mRSXQHvHRBs" />
+                        <p className="font-semibold mb-0 mt-2">July 2026</p>
                       </div>
                     </div>
                   </div>
                   <div className="col-lg-6 mb-4">
                     <div className="card">
                       <div className="card-body">
-                        <YoutubeEmbed videoId="AuYBaXC8-M4" />
+                        <YoutubeEmbed videoId="3JTfIHJMotM" />
                         <p className="font-semibold mb-0 mt-2">
-                          MCP Introduction, May 2025
+                          From Knowledge Graph to Context, July 2026
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary

The /events page 'most recent' feature videos were still showing May 2025. Update both slots to the July 2026 videos.

## What changed

`src/pages/events.tsx` — the two feature-video cards under 'Here's what's most recent':
- Slot 1: NxqCn-3XkVc (May 2025) to mRSXQHvHRBs (July 2026 Community Meeting), label 'July 2026'
- Slot 2: AuYBaXC8-M4 (MCP Introduction, May 2025) to 3JTfIHJMotM, label 'From Knowledge Graph to Context, July 2026'

## Test plan

- [ ] Netlify preview /events renders both July 2026 videos and they play

🤖 Generated with [Claude Code](https://claude.com/claude-code)