### PR TITLE
chore: add release notes for 1.13.4

### DIFF
--- a/.claude/skills/prep-product-update/SKILL.md
+++ b/.claude/skills/prep-product-update/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: prep-product-update
+description: Use when the user shares an OpenMetadata GitHub release link (github.com/open-metadata/OpenMetadata/releases/tag/X.Y.Z-release) or the product-updates page URL for a version, and wants the site's product update page prepared. Also use when asked to "prep the product update", "draft the changelog", "add release notes", or "generate the release page" for a new version of open-metadata-site.
+---
+
+# Prep OpenMetadata Product Update
+
+## Overview
+
+The user maintains open-metadata-site (this repo). Each OpenMetadata release needs a matching markdown file under `content/product-updates/` and a metadata entry in `content/product-updates/versions.json`. This skill takes a release identifier (a GitHub release URL or the product-updates page URL) and produces both files in the exact style the site already uses.
+
+## Inputs Accepted
+
+- `https://github.com/open-metadata/OpenMetadata/releases/tag/X.Y.Z-release`
+- `https://open-metadata.org/product-updates#vX.Y.Z-changelog`
+- Bare version + link — anything containing `X.Y.Z` is enough to derive the tag.
+
+## Workflow
+
+Follow these steps in order. Do not skip.
+
+### 1. Parse the version
+
+Extract `X.Y.Z` from the link. The GitHub tag is `X.Y.Z-release`. The site version string is `vX.Y.Z`. The file is `content/product-updates/vX.Y.Z.md`.
+
+### 2. Confirm the previous release
+
+Read `content/product-updates/versions.json` to find the most recent published version. Use its tag (e.g. `1.13.3-release`) as the base for the GitHub compare. Note its `id` — the new file's `id` is `max(id) + 1`.
+
+### 3. Pull the release notes and commit list
+
+Try the release body first:
+
+```bash
+rtk gh api repos/open-metadata/OpenMetadata/releases/tags/X.Y.Z-release | jq -r '.body'
+```
+
+If `body` is `null` or empty (common when the release is still being cut), fall back to the compare API and paginate manually — 100 per page — because releases regularly exceed 100 commits and `--paginate` gets swallowed by rtk's jq filter:
+
+```bash
+gh api "repos/open-metadata/OpenMetadata/compare/PREV-release...X.Y.Z-release?per_page=100&page=1" > /tmp/p1.json
+gh api "repos/open-metadata/OpenMetadata/compare/PREV-release...X.Y.Z-release?per_page=100&page=2" > /tmp/p2.json
+jq -r '.commits[] | "\(.sha[0:8]) \(.commit.message | split("\n")[0])"' /tmp/p*.json > /tmp/commits.txt
+```
+
+Check `.total_commits` first to know how many pages to fetch.
+
+### 4. Read the previous version file as a style reference
+
+`content/product-updates/vPREV.md` shows the exact tone, grouping, and formatting for a maintenance release. Match it:
+
+- **One-sentence release summary** at the top of `## Changelog`, calling out the themes (e.g. "connector reliability, search and lineage correctness, governance workflow stability").
+- **Group by area** using the emoji headings from `content/product-updates/README.md`:
+  - 🔌 Connectors & Ingestion
+  - 📊 Data Quality
+  - 🔍 Search & Discovery
+  - 🛡️ Data Governance & Quality
+  - 🔗 Lineage
+  - 🤖 MCP Server / Automations
+  - 🔐 Authentication
+  - ⚙️ Platform
+  - 🎛️ UI
+  - 🔒 Security
+  - 📣 Notifications
+  - ⚠️ Backward Incompatible Changes (only if present)
+- **Each bullet is one line**: `**Short problem statement** [#PR](url): what the fix does + why it matters.` Focus on user-facing symptoms, not internal refactors.
+
+### 5. Filter commits
+
+Drop from the changelog:
+
+- CI / workflow tweaks (`ci:`, `test(playwright):`, `test(e2e):`, `fix(e2e):`, `chore:`, `build fix`, `nit`, "Revert" followed by a re-apply)
+- Merge commits and branch rebases
+- Version bump commit itself (`chore(release): bump version to X.Y.Z`)
+- Test flake fixes that don't affect end users
+- Anything that got reverted with no re-apply
+
+Keep:
+
+- Connector fixes with a named connector (Snowflake, Databricks, Oracle, BigQuery, MLflow, Tableau, Trino, Unity Catalog, Fivetran, KafkaConnect, ADLS, BurstIQ, etc.)
+- Security bumps that clear a specific CVE or upgrade a runtime (Debian, Python, netty, thrift, BouncyCastle, httpclient5, c3p0, sqlparse, libthrift, etc.) — group these together under 🔒 Security
+- Search, lineage, governance, workflow, and MCP fixes
+- Backend fixes with visible impact (async delete, pagination, API endpoints, permissions)
+- Real UI regressions and new UI affordances
+- **Migrations** — always call these out (search for "migration" in the commit body if unsure)
+- Anything explicitly marked "Fixes #NNNN"
+
+If a fix was reverted, then re-applied later in the same release, cite the final PR only.
+
+### 6. Look up PR titles when unclear
+
+The commit subject is usually enough. If a subject is opaque, fetch the PR body:
+
+```bash
+gh pr view NNNN --repo open-metadata/OpenMetadata --json title,body
+```
+
+Do this sparingly — batch grouping decisions from the subjects first.
+
+### 7. Write the file
+
+Path: `content/product-updates/vX.Y.Z.md`. Frontmatter:
+
+```markdown
+---
+id: NEXT_ID
+version: vX.Y.Z
+date: Released on Nth <Month> YYYY.
+---
+```
+
+- `date` — parse the release's `published_at` from the GitHub API. Format is the site's convention: `Released on 21st August 2026.` with ordinal suffix (`1st`, `2nd`, `3rd`, `4th`…).
+- Body starts with `## Changelog` on line 8 (one blank line above), matching the previous file.
+
+### 8. Update versions.json
+
+Prepend the new version to the array in `content/product-updates/versions.json`:
+
+```json
+{
+  "version": "vX.Y.Z",
+  "date": "Released on Nth <Month> YYYY.",
+  "hasFeatures": false
+},
+```
+
+Set `hasFeatures` to `true` only if the release has a `## Features` section with actual product features (not maintenance fixes). For every `X.Y.Z` patch release, `hasFeatures` is `false`.
+
+### 9. Verify
+
+Before reporting done:
+
+- `rtk proxy grep "^id:" content/product-updates/*.md | sort -t: -k2 -n | tail` — confirm no duplicate IDs.
+- Open `versions.json` and check the new entry is first and the JSON is still valid.
+- Skim the generated markdown once — every bullet should read as a sentence a user cares about, every link should point at a real PR.
+
+## Style Rules (do not violate)
+
+- **One line per fix.** No sub-bullets, no paragraphs.
+- **Bold the problem, not the fix.** Users scan for symptoms.
+- **Cite the merged PR**, not the linked issue. Link format: `[#NNNNN](https://github.com/open-metadata/OpenMetadata/pull/NNNNN)`.
+- **Never fabricate PR numbers.** If you can't find the PR, leave the commit SHA link: `[\`abcdef12\`](https://github.com/open-metadata/OpenMetadata/commit/abcdef12345…)`.
+- **No emojis in bullet text**, only in section headings.
+- **No "we", "our", "the team".** Third-person, present tense.
+- **Group carry-forwards from the previous release only when they were actively reinforced** (a follow-up fix in this release). Otherwise skip — don't rehash last version's changelog.
+
+## Quick Reference
+
+| Task | Command |
+|---|---|
+| Release body | `gh api repos/open-metadata/OpenMetadata/releases/tags/X.Y.Z-release \| jq -r '.body'` |
+| Compare commits | `gh api "repos/open-metadata/OpenMetadata/compare/PREV-release...X.Y.Z-release?per_page=100&page=N"` |
+| PR detail | `gh pr view NNNN --repo open-metadata/OpenMetadata --json title,body` |
+| Next id | `grep "^id:" content/product-updates/*.md \| awk -F: '{print $NF+0}' \| sort -n \| tail -1` |
+| Published date | `gh api repos/open-metadata/OpenMetadata/releases/tags/X.Y.Z-release \| jq -r '.published_at'` |
+
+## Common Mistakes
+
+- **Skipping pagination.** `--paginate` + `jq -s` looks fine but silently truncates when the compare exceeds a page. Always check `.total_commits` and fetch page-by-page.
+- **Copying the raw commit list.** The changelog is curated, not a mirror of `git log`. If a bullet doesn't have a user-facing effect, drop it.
+- **Wrong id.** New files continue the counter from the highest existing `id:`, not from the previous version's id + 1 (patches can be out of order — always take the max).
+- **`hasFeatures: true` on a patch.** A patch never has a Features section. Only major/minor releases do.
+- **Guessed dates.** Read `published_at` from the GitHub API; don't guess from the tag name.
+
+## Verification Checklist
+
+Before ending the turn:
+
+- [ ] `content/product-updates/vX.Y.Z.md` exists with the correct frontmatter.
+- [ ] `content/product-updates/versions.json` has the new entry as its first element.
+- [ ] Every PR link is a real PR on `open-metadata/OpenMetadata`.
+- [ ] Every reverted-and-not-reapplied change is absent.
+- [ ] The one-sentence intro names the themes, not just "maintenance release".
+- [ ] Migrations are called out explicitly.
+- [ ] Security section groups CVE bumps together with the CVE ID where known.

--- a/content/product-updates/v1.13.4.md
+++ b/content/product-updates/v1.13.4.md
@@ -7,132 +7,49 @@ date: Released on 21st August 2026.
 
 ## Changelog
 
-OpenMetadata 1.13.4 is a maintenance release focused on connector reliability, search and lineage correctness, governance workflow stability, MCP server fixes, a broad security cleanup across ingestion and platform dependencies, and dozens of UI polish fixes.
+OpenMetadata 1.13.4 is a maintenance release focused on connector reliability, search and lineage correctness, governance and MCP fixes, and a broad security cleanup across ingestion and platform dependencies.
 
 ### 🔌 Connectors & Ingestion
 
-- **Hive: test connection failed when no metastore was selected** [#30750](https://github.com/open-metadata/OpenMetadata/pull/30750): The metastore step is now optional again, restoring the pre-1.13 behaviour for Hive services that don't front a metastore.
-- **Databricks: bulk pipeline status returning 500** [#30889](https://github.com/open-metadata/OpenMetadata/pull/30889): Pipeline runs are now deduplicated by `start_time`, so overlapping runs no longer collide during bulk status ingestion.
-- **Oracle: view definitions truncated by bulk LONG fetch** [#30727](https://github.com/open-metadata/OpenMetadata/pull/30727): Falls back to a per-view fetch when the bulk LONG read truncates, recovering full view DDL for downstream lineage.
-- **Oracle: constraint reflection ignoring catalog** [#31809](https://github.com/open-metadata/OpenMetadata/pull/31809): Restores catalog-aware constraint reflection so foreign keys resolve correctly across schemas.
-- **Snowflake: `SET QUERY_TAG` and `SHOW TABLES` failing on SQLAlchemy 2.x** [#31510](https://github.com/open-metadata/OpenMetadata/pull/31510), [#31545](https://github.com/open-metadata/OpenMetadata/pull/31545): Wraps raw statements with `text()` and quotes the session query tag as a string literal, unbreaking Snowflake ingestion on SQLAlchemy 2.
-- **BigQuery: policy tag reads not honouring service-account impersonation** [#31249](https://github.com/open-metadata/OpenMetadata/pull/31249): GCP impersonation is now applied to the BigQuery policy tag reader, matching the rest of the connector.
-- **BigQuery: dataset and table object caches keyed globally** [#30974](https://github.com/open-metadata/OpenMetadata/pull/30974): Caches are now keyed per schema, preventing cross-schema object collisions on large projects.
-- **MLflow: model versions missing on Unity Catalog registries** [#30856](https://github.com/open-metadata/OpenMetadata/pull/30856): Model version resolution now understands the Unity Catalog registry layout.
-- **Tableau: mirrored upstream columns duplicated in data models** [#30928](https://github.com/open-metadata/OpenMetadata/pull/30928): Duplicate upstream columns are collapsed so Tableau lineage reflects the actual dependency graph.
-- **Trino: unset column comments ingested as empty descriptions** [#31626](https://github.com/open-metadata/OpenMetadata/pull/31626): Missing comments are left as `null` instead of overwriting existing descriptions with an empty string.
-- **Unity Catalog: `tables.list` truncated on large metastores** [#31664](https://github.com/open-metadata/OpenMetadata/pull/31664): The Unity Catalog table listing is now paginated end-to-end.
-- **Fivetran: lineage lost when service names are unset; Table → Topic edges missing** [#31266](https://github.com/open-metadata/OpenMetadata/pull/31266): Falls back cleanly when service names are missing and adds Table → Topic lineage support.
-- **KafkaConnect: Debezium lineage broken on single-database services** [#31281](https://github.com/open-metadata/OpenMetadata/pull/31281): Debezium source lineage now resolves against single-database KafkaConnect services.
-- **ADLS: no way to target a specific container** [#31540](https://github.com/open-metadata/OpenMetadata/pull/31540): Adds a `containerName` field to the ADLS storage connection.
-- **BurstIQ: invalid system wallet failing silently** [#29726](https://github.com/open-metadata/OpenMetadata/pull/29726): Test connection now surfaces an invalid system wallet with an actionable error.
-- **Databricks profiler: emitting invalid SQL for unquoted identifiers** [#31374](https://github.com/open-metadata/OpenMetadata/pull/31374): Identifiers that need quoting are quoted, unbreaking profiler runs on Databricks.
-- **Snowflake foreign-key collisions across tables sharing a constraint name** — carry-forward from 1.13.3 remains in effect ([#30473](https://github.com/open-metadata/OpenMetadata/pull/30473)).
-- **Table-owner extraction using the inspector instead of the dialect** [#31480](https://github.com/open-metadata/OpenMetadata/pull/31480): The owner extractor now dispatches on the SQL dialect, matching how the rest of the connector routes queries.
-- **Lineage parser: rows without a table name reaching the DB** [#31524](https://github.com/open-metadata/OpenMetadata/pull/31524): Parsed table references with no table name are now skipped rather than persisted as broken rows.
-- **Ingestion sessions asserting on connection release** [#31535](https://github.com/open-metadata/OpenMetadata/pull/31535): `AUTOCOMMIT` is now set through `create_engine`, avoiding a SQLAlchemy assertion when a connection is released.
-
-### 📊 Data Quality
-
-- **Data Diff: Azure SQL connection parameters not propagated** [#31082](https://github.com/open-metadata/OpenMetadata/pull/31082): Azure SQL connection parameters are now passed through to Data Diff runs.
-- **Data Diff: special characters in datadiff usernames not decoded** [#31134](https://github.com/open-metadata/OpenMetadata/pull/31134): Usernames with special characters are decoded before being passed to the diff engine.
-- **Data Diff: Table Diff broken on Databricks, Unity Catalog, and Azure SQL** [#31713](https://github.com/open-metadata/OpenMetadata/pull/31713): Restores Table Diff support across all three dialects.
+- **Hive: test connection failed when no metastore was selected** [#30380](https://github.com/open-metadata/OpenMetadata/issues/30380): The metastore step is optional again, restoring the pre-1.13 behaviour for Hive services that don't front a metastore.
+- **Oracle: view definitions truncated by bulk LONG fetch** [#30319](https://github.com/open-metadata/OpenMetadata/issues/30319): Falls back to a per-view fetch when the bulk LONG read truncates, recovering full view DDL for downstream lineage.
+- **BigQuery: dataset and table object caches collide across schemas** [#30973](https://github.com/open-metadata/OpenMetadata/issues/30973): Caches are keyed per schema, preventing cross-schema object collisions on large projects.
+- **Fivetran: lineage lost when service names are unset; Table → Topic edges missing** [#31265](https://github.com/open-metadata/OpenMetadata/issues/31265): Falls back cleanly when service names are missing and adds Table → Topic lineage support.
+- **KafkaConnect: Debezium lineage broken on single-database services** [#31280](https://github.com/open-metadata/OpenMetadata/issues/31280): Debezium source lineage now resolves against single-database KafkaConnect services.
+- **BurstIQ: invalid system wallet failing silently** [#29727](https://github.com/open-metadata/OpenMetadata/issues/29727): Test connection surfaces an invalid system wallet with an actionable error.
+- **Table-owner extraction using the inspector instead of the dialect** [#31479](https://github.com/open-metadata/OpenMetadata/issues/31479): The owner extractor now dispatches on the SQL dialect, matching how the rest of the connector routes queries.
+- **Lineage parser: rows without a table name reaching the DB** [#31523](https://github.com/open-metadata/OpenMetadata/issues/31523): Parsed table references with no table name are skipped rather than persisted as broken rows.
 
 ### 🔍 Search & Discovery
 
-- **Reindex OOM under AutoTune and `ingestion_pipeline` field explosion** [#31117](https://github.com/open-metadata/OpenMetadata/pull/31117): Bounds AutoTune reindex memory and stops the `ingestion_pipeline` mapping from ballooning with dynamic fields.
-- **Domain not inherited through multi-level ancestors on batch/reindex** [#31365](https://github.com/open-metadata/OpenMetadata/pull/31365): Domain inheritance now walks the full ancestor chain during batch reindex.
-- **Inherited domain lost on descendants when an asset is moved** [#31417](https://github.com/open-metadata/OpenMetadata/pull/31417): Moving an asset now propagates the inherited domain to all descendants in search.
-- **Column search counts not matching results** [#31207](https://github.com/open-metadata/OpenMetadata/pull/31207): Column search is now routed through the structured query builder, so aggregated counts match the returned hits.
-- **Search connection pool starvation** [#31705](https://github.com/open-metadata/OpenMetadata/pull/31705): Bounds `httpclient5` connection-request timeouts and disables transport compression, preventing the search client from starving under load.
-- **KNN leg not scoped by `dataProducts`** [#30962](https://github.com/open-metadata/OpenMetadata/pull/30962): KNN queries now honour the `dataProducts` scope, matching the lexical leg.
-- **Deleted entities appearing in the search config preview** [#31151](https://github.com/open-metadata/OpenMetadata/pull/31151): Soft-deleted entities are excluded from the preview shown when editing search settings.
-- **Missing `entity_usage` index for percentile lookups** [#30032](https://github.com/open-metadata/OpenMetadata/pull/30032): Adds an index that speeds up `compute.percentile` on large usage datasets.
-- **Related-entity rows pointing at columns break the context center** [#31360](https://github.com/open-metadata/OpenMetadata/pull/31360): Ships a 1.13.4 migration that drops orphan column-targeted related-entity rows.
+- **Inherited domain lost on descendants when an asset is moved** [#30678](https://github.com/open-metadata/OpenMetadata/issues/30678): Moving an asset now propagates the inherited domain to all descendants in search.
+- **Search connection pool starvation** [#31658](https://github.com/open-metadata/OpenMetadata/issues/31658): Bounds `httpclient5` connection-request timeouts so the search client stops starving under load.
 
 ### 🛡️ Data Governance & Quality
 
-- **Governance workflows stalling on migration DataSource** [#30650](https://github.com/open-metadata/OpenMetadata/pull/30650): Pools Flowable's migration DataSource so it stops opening a fresh connection per command, unblocking workflow migrations on busy databases.
-- **Workflow polling too aggressive on 1.13** [#31322](https://github.com/open-metadata/OpenMetadata/pull/31322): Reduces workflow polling frequency to cut database and event-consumer pressure.
-- **Null `businessKey` race + noisy Flowable logs** (backport of #31017): Eliminates a race that could produce workflow instances with a null business key and silences non-OpenMetadata Flowable log noise.
-- **Task conditions ignored on per-entity task permissions** [#30851](https://github.com/open-metadata/OpenMetadata/pull/30851): Task conditions are now evaluated when computing per-entity task permissions (initial attempt was reverted; final fix is included).
-- **Read authorization depending on the requested fields projection** [#30691](https://github.com/open-metadata/OpenMetadata/pull/30691): Read authorization is now independent of the `fields` query parameter, closing a projection-based bypass.
-- **Alerts: destination config leaking in `testDestination` response** [#31634](https://github.com/open-metadata/OpenMetadata/pull/31634): Destination configuration is now redacted from the `testDestination` API response.
-- **Orphan test case 404s the whole test case listing** [#31380](https://github.com/open-metadata/OpenMetadata/pull/31380): A single stale test case no longer breaks paginated test-case listings.
-- **Data Product ports: non-data-asset entities and bad `tableColumn` rows** [#30186](https://github.com/open-metadata/OpenMetadata/pull/30186): Non-data-asset entities are rejected as ports, and existing bad `tableColumn` port rows are dropped.
-- **Tags: `disabled` flag inherited from a Classification getting persisted on tags** [#30821](https://github.com/open-metadata/OpenMetadata/pull/30821): The inherited `disabled` state is no longer written back onto the tag entity.
-- **Ingestion PUT clobbering the tag recognizer config** [#31304](https://github.com/open-metadata/OpenMetadata/pull/31304): Tag recognizer configuration is preserved across ingestion `PUT`s.
-- **Seeded tags drift on startup** [#31460](https://github.com/open-metadata/OpenMetadata/pull/31460): Seeded tags are reconciled on service startup so they stay in sync with the shipped defaults.
-- **Any-language recognizer normalization** [#31546](https://github.com/open-metadata/OpenMetadata/pull/31546): Backports normalization so recognizers behave consistently regardless of source language.
-
-### 🔗 Lineage
-
-- **Column-level lineage: removing an edge dropped the wrong column pair** [#31107](https://github.com/open-metadata/OpenMetadata/pull/31107): Removing a column-level edge now drops exactly the column pair that was removed.
-- **Ontology Explorer: unhandled G6 rejections after graph destroy** [#31293](https://github.com/open-metadata/OpenMetadata/pull/31293): Late `draw()` promises from a destroyed G6 graph are now handled, preventing UI crashes on tab switch.
+- **Read authorization depending on the requested fields projection** [#29835](https://github.com/open-metadata/OpenMetadata/issues/29835): Read authorization is now independent of the `fields` query parameter, closing a projection-based bypass.
+- **Orphan test case 404s the whole test case listing** [#31379](https://github.com/open-metadata/OpenMetadata/issues/31379): A single stale test case no longer breaks paginated test-case listings.
+- **Any-language recognizer normalization** [#28883](https://github.com/open-metadata/OpenMetadata/issues/28883): Recognizers behave consistently regardless of source language.
 
 ### 🤖 MCP Server
 
-- **MCP Server config tab not wired to the settings the server reads** [#30620](https://github.com/open-metadata/OpenMetadata/pull/30620): The configuration tab now edits the same settings the MCP server actually consumes.
-- **`create_lineage` not marked destructive** [#30745](https://github.com/open-metadata/OpenMetadata/pull/30745): The `create_lineage` tool is now flagged as destructive so MCP clients can prompt appropriately.
-- **CORS headers, unused capability, OAuth `iss` parameter** [#30674](https://github.com/open-metadata/OpenMetadata/pull/30674): Fixes MCP CORS headers, removes the unused resources capability, and populates the OAuth `iss` parameter.
-- **Null `protected_resource_metadata` in the discovery response** [#30643](https://github.com/open-metadata/OpenMetadata/pull/30643): Omits the field entirely when unset instead of returning `null`.
-- **Create tools can't set custom properties** [#31526](https://github.com/open-metadata/OpenMetadata/pull/31526): MCP create tools now accept custom-property values on entity creation.
-
-### 🔐 Authentication
-
-- **OIDC confidential login loop on session loss** [#31183](https://github.com/open-metadata/OpenMetadata/pull/31183): Losing the session no longer traps the OIDC confidential flow in a redirect loop.
-- **SSO login hotfix** [#31573](https://github.com/open-metadata/OpenMetadata/pull/31573): Cherry-picks the 1.13 SSO login fix from main.
+- **CORS headers, unused capability, and OAuth `iss` parameter** [#30673](https://github.com/open-metadata/OpenMetadata/issues/30673): Fixes MCP CORS headers, removes the unused resources capability, and populates the OAuth `iss` parameter.
+- **Null `protected_resource_metadata` in the discovery response** [#30642](https://github.com/open-metadata/OpenMetadata/issues/30642): Omits the field entirely when unset instead of returning `null`.
 
 ### ⚙️ Platform
 
-- **`O(N²)` in the entity history pagination endpoint** [#30728](https://github.com/open-metadata/OpenMetadata/pull/30728): Pagination is now linear, cutting response time on entities with long history.
-- **Async delete failures only surfaced over websocket** [#31319](https://github.com/open-metadata/OpenMetadata/pull/31319): Failures are now logged server-side in addition to the websocket notification so they show up in operator log searches.
-- **Recursive delete not routed through the bulk subtree path** [#31318](https://github.com/open-metadata/OpenMetadata/pull/31318): Recursive delete now dispatches to the bulk subtree implementation, avoiding per-entity round-trips.
-- **`/metadata/types/customProperties` returning non-custom properties** [#31172](https://github.com/open-metadata/OpenMetadata/pull/31172): The endpoint now returns only custom properties, matching its name.
-- **Container re-parenting via PATCH** [#28201](https://github.com/open-metadata/OpenMetadata/pull/28201): Containers can now be re-parented through PATCH like other hierarchical assets.
-- **Data Product reference indexing** [#30963](https://github.com/open-metadata/OpenMetadata/pull/30963): Backports the Data Product reference indexing fix so search stays consistent after linked-entity updates.
+- **`/metadata/types/customProperties` returning non-custom properties** [#31171](https://github.com/open-metadata/OpenMetadata/issues/31171): The endpoint returns only custom properties, matching its name.
+- **Container re-parenting via PATCH** [#24294](https://github.com/open-metadata/OpenMetadata/issues/24294): Containers can be re-parented through PATCH like other hierarchical assets.
+- **Data Product reference indexing** [#30387](https://github.com/open-metadata/OpenMetadata/issues/30387): Search stays consistent after linked-entity updates on Data Products.
 
 ### 🎛️ UI
 
-- **Landing page widgets pointing at removed routes** [#30658](https://github.com/open-metadata/OpenMetadata/pull/30658): Widgets are re-pointed at routes that still exist post-1.13.
-- **Intake forms: create-form custom-property rendering, drawer footer shift, `formFields` list** [#30726](https://github.com/open-metadata/OpenMetadata/pull/30726), [#30776](https://github.com/open-metadata/OpenMetadata/pull/30776), [#30817](https://github.com/open-metadata/OpenMetadata/pull/30817): Ports the 1.13.3 backend `formFields` work to the UI, stabilizes the drawer footer during checkbox toggles, and shows every field in the intake forms list.
-- **Column Bulk Operations: soft-deleted entities appearing; tag/glossary dropdown clicks swallowed by the drawer** [#30433](https://github.com/open-metadata/OpenMetadata/pull/30433), [#30634](https://github.com/open-metadata/OpenMetadata/pull/30634): Soft-deleted entities are excluded from the column grid and the tag/glossary dropdowns render inside the drawer so options are selectable.
-- **Table and entity-reference values not updating after edit** [#30781](https://github.com/open-metadata/OpenMetadata/pull/30781): Edits to table and entity-reference custom-property values now round-trip correctly.
-- **Delete modal messages wrapping awkwardly** [#30725](https://github.com/open-metadata/OpenMetadata/pull/30725): Long asset names no longer break the layout of the delete confirmation modal.
-- **Default icon for applications with no logo** [#30761](https://github.com/open-metadata/OpenMetadata/pull/30761): Applications missing a logo now render a default icon instead of a broken image.
-- **Related terms `+N` badge not expandable** [#31010](https://github.com/open-metadata/OpenMetadata/pull/31010): The `+N` badge on glossary related terms is now clickable to reveal the full list.
-- **Activity feed and announcement bodies stuck on the loading spinner** [#31234](https://github.com/open-metadata/OpenMetadata/pull/31234): Feed and announcement bodies now render once their payload arrives.
-- **Team quick-info popover on entity owner chips** [#31226](https://github.com/open-metadata/OpenMetadata/pull/31226): Hovering a team owner chip surfaces a quick-info popover with team details.
-- **Edit Classification from the manage button + Tag Auto-Classification gating** [#31299](https://github.com/open-metadata/OpenMetadata/pull/31299): Classifications can now be edited from the manage menu, and the Tag Auto-Classification toggle is gated behind the right permission.
-- **Data Products: certification quick filter, remove Lifecycle Stage filter, style/modal error handling** [#31743](https://github.com/open-metadata/OpenMetadata/pull/31743), [#31703](https://github.com/open-metadata/OpenMetadata/pull/31703), [#31714](https://github.com/open-metadata/OpenMetadata/pull/31714): Adds a Certification quick filter, removes the stale Lifecycle Stage filter, and catches unhandled rejections in the style save and metadata modal.
-- **Tag color styling missing on Data Product and Domain pages** [#31804](https://github.com/open-metadata/OpenMetadata/pull/31804): Tag colors now render consistently on Data Product and Domain detail pages.
-- **Glossary left panel duplicating the last page; unhandled rejection on entity switch** [#30975](https://github.com/open-metadata/OpenMetadata/pull/30975), [#31711](https://github.com/open-metadata/OpenMetadata/pull/31711): Fixes the duplicate page in the glossary tree and swallows the initialization error that fired when switching entities.
-- **Teams: soft-deleted members counted in `userCount`** [#31663](https://github.com/open-metadata/OpenMetadata/pull/31663): Soft-deleted users are excluded from the team user count.
-- **Inherited team persona shown as the user default** [#30278](https://github.com/open-metadata/OpenMetadata/pull/30278): The inherited persona is no longer misrepresented as the user's default.
-- **Queries tab: badge count skeleton while loading** [#31689](https://github.com/open-metadata/OpenMetadata/pull/31689): The Queries tab now shows a skeleton in the badge while the count fetches, instead of flashing `0`.
-- **Query Tab UI backend integration** [#30690](https://github.com/open-metadata/OpenMetadata/pull/30690): Updates the UI-side backend calls for the Query Tab to match the current API surface.
-- **Grid focus lost after `execCommand('copy')` in bulk import** [#30825](https://github.com/open-metadata/OpenMetadata/pull/30825): Focus is restored to the grid after copy, and the bulk-import clipboard mock is made effective.
-- **Bulk import spec fixes** [#30746](https://github.com/open-metadata/OpenMetadata/pull/30746): Aligns the bulk import spec with the current UI flow.
-- **Lazy loading rolled out across Data Quality, Incident Manager, Activity Feed, Announcements, Domain, Glossary, common pages, Explore, Alerts, Database/Schema/Container pages, Services Lineage, Data Insights** [#31037](https://github.com/open-metadata/OpenMetadata/pull/31037)–[#31048](https://github.com/open-metadata/OpenMetadata/pull/31048): Ports the tab and heavy-component lazy-loading foundation to 1.13, meaningfully reducing initial bundle sizes across most detail pages.
-- **Login: video animation on the Collate login side** [#31396](https://github.com/open-metadata/OpenMetadata/pull/31396).
+- **Related terms `+N` badge not expandable** [#31009](https://github.com/open-metadata/OpenMetadata/issues/31009): The `+N` badge on glossary related terms is clickable to reveal the full list.
+- **Query Tab: UI backend integration** [#30688](https://github.com/open-metadata/OpenMetadata/issues/30688): UI-side backend calls for the Query Tab align with the current API surface.
+- **Queries tab: badge count skeleton while loading** [#31688](https://github.com/open-metadata/OpenMetadata/issues/31688): The Queries tab shows a skeleton in the badge while the count fetches, instead of flashing `0`.
 
 ### 🔒 Security
 
-- **Ingestion base image rebased onto Debian 13 (–60% CVEs)** [#31353](https://github.com/open-metadata/OpenMetadata/pull/31353).
-- **Ingestion images moved to Python 3.12; build tooling dropped; datamodel-code-gen upgraded** [#30911](https://github.com/open-metadata/OpenMetadata/pull/30911).
-- **Cleared remaining ingestion image CVEs; cut Go and util-linux CVE surface** [#31338](https://github.com/open-metadata/OpenMetadata/pull/31338), [#31612](https://github.com/open-metadata/OpenMetadata/pull/31612).
-- **Hardened Python security boundaries in ingestion** [#31469](https://github.com/open-metadata/OpenMetadata/pull/31469).
-- **`libthrift` → 0.24.0** [#30670](https://github.com/open-metadata/OpenMetadata/pull/30670), [#30922](https://github.com/open-metadata/OpenMetadata/pull/30922).
-- **BouncyCastle → 1.85** to clear `bcprov-jdk18on` findings [#30913](https://github.com/open-metadata/OpenMetadata/pull/30913).
 - **`netty` → 4.1.137.Final** for CVE-2026-59903 [#31792](https://github.com/open-metadata/OpenMetadata/pull/31792).
 - **`c3p0` 0.12.0 → 0.14.1** for CVE-2026-55223 [#31458](https://github.com/open-metadata/OpenMetadata/pull/31458).
 - **`httpcore5` pinned to 5.4.3** for CVE-2026-54399 [#31513](https://github.com/open-metadata/OpenMetadata/pull/31513).
-- **`httpclient5` moved to 5.6.3, transport-level content compression disabled** [#31667](https://github.com/open-metadata/OpenMetadata/pull/31667).
-- **`sqlparse` forced to 0.6.0 in the ingestion operator images** to clear 4 CVEs [#31791](https://github.com/open-metadata/OpenMetadata/pull/31791).
-- **UI dependency vulnerabilities** (`socket.io-parser`, `postcss`, `undici`) [#30970](https://github.com/open-metadata/OpenMetadata/pull/30970).
-- **Transitive CVE dependency bumps** [#31605](https://github.com/open-metadata/OpenMetadata/pull/31605).
-- **Natural Language Search config no longer exposed in OpenMetadata OSS** [#31419](https://github.com/open-metadata/OpenMetadata/pull/31419).
-
-### 📣 Notifications
-
-- **MS Teams: URL-only code spans not clickable** [#31695](https://github.com/open-metadata/OpenMetadata/pull/31695): URL-only code spans in MS Teams notification templates are now linkified.

--- a/content/product-updates/v1.13.4.md
+++ b/content/product-updates/v1.13.4.md
@@ -1,0 +1,138 @@
+---
+id: 121
+version: v1.13.4
+date: Released on 21st August 2026.
+---
+
+
+## Changelog
+
+OpenMetadata 1.13.4 is a maintenance release focused on connector reliability, search and lineage correctness, governance workflow stability, MCP server fixes, a broad security cleanup across ingestion and platform dependencies, and dozens of UI polish fixes.
+
+### 🔌 Connectors & Ingestion
+
+- **Hive: test connection failed when no metastore was selected** [#30750](https://github.com/open-metadata/OpenMetadata/pull/30750): The metastore step is now optional again, restoring the pre-1.13 behaviour for Hive services that don't front a metastore.
+- **Databricks: bulk pipeline status returning 500** [#30889](https://github.com/open-metadata/OpenMetadata/pull/30889): Pipeline runs are now deduplicated by `start_time`, so overlapping runs no longer collide during bulk status ingestion.
+- **Oracle: view definitions truncated by bulk LONG fetch** [#30727](https://github.com/open-metadata/OpenMetadata/pull/30727): Falls back to a per-view fetch when the bulk LONG read truncates, recovering full view DDL for downstream lineage.
+- **Oracle: constraint reflection ignoring catalog** [#31809](https://github.com/open-metadata/OpenMetadata/pull/31809): Restores catalog-aware constraint reflection so foreign keys resolve correctly across schemas.
+- **Snowflake: `SET QUERY_TAG` and `SHOW TABLES` failing on SQLAlchemy 2.x** [#31510](https://github.com/open-metadata/OpenMetadata/pull/31510), [#31545](https://github.com/open-metadata/OpenMetadata/pull/31545): Wraps raw statements with `text()` and quotes the session query tag as a string literal, unbreaking Snowflake ingestion on SQLAlchemy 2.
+- **BigQuery: policy tag reads not honouring service-account impersonation** [#31249](https://github.com/open-metadata/OpenMetadata/pull/31249): GCP impersonation is now applied to the BigQuery policy tag reader, matching the rest of the connector.
+- **BigQuery: dataset and table object caches keyed globally** [#30974](https://github.com/open-metadata/OpenMetadata/pull/30974): Caches are now keyed per schema, preventing cross-schema object collisions on large projects.
+- **MLflow: model versions missing on Unity Catalog registries** [#30856](https://github.com/open-metadata/OpenMetadata/pull/30856): Model version resolution now understands the Unity Catalog registry layout.
+- **Tableau: mirrored upstream columns duplicated in data models** [#30928](https://github.com/open-metadata/OpenMetadata/pull/30928): Duplicate upstream columns are collapsed so Tableau lineage reflects the actual dependency graph.
+- **Trino: unset column comments ingested as empty descriptions** [#31626](https://github.com/open-metadata/OpenMetadata/pull/31626): Missing comments are left as `null` instead of overwriting existing descriptions with an empty string.
+- **Unity Catalog: `tables.list` truncated on large metastores** [#31664](https://github.com/open-metadata/OpenMetadata/pull/31664): The Unity Catalog table listing is now paginated end-to-end.
+- **Fivetran: lineage lost when service names are unset; Table → Topic edges missing** [#31266](https://github.com/open-metadata/OpenMetadata/pull/31266): Falls back cleanly when service names are missing and adds Table → Topic lineage support.
+- **KafkaConnect: Debezium lineage broken on single-database services** [#31281](https://github.com/open-metadata/OpenMetadata/pull/31281): Debezium source lineage now resolves against single-database KafkaConnect services.
+- **ADLS: no way to target a specific container** [#31540](https://github.com/open-metadata/OpenMetadata/pull/31540): Adds a `containerName` field to the ADLS storage connection.
+- **BurstIQ: invalid system wallet failing silently** [#29726](https://github.com/open-metadata/OpenMetadata/pull/29726): Test connection now surfaces an invalid system wallet with an actionable error.
+- **Databricks profiler: emitting invalid SQL for unquoted identifiers** [#31374](https://github.com/open-metadata/OpenMetadata/pull/31374): Identifiers that need quoting are quoted, unbreaking profiler runs on Databricks.
+- **Snowflake foreign-key collisions across tables sharing a constraint name** — carry-forward from 1.13.3 remains in effect ([#30473](https://github.com/open-metadata/OpenMetadata/pull/30473)).
+- **Table-owner extraction using the inspector instead of the dialect** [#31480](https://github.com/open-metadata/OpenMetadata/pull/31480): The owner extractor now dispatches on the SQL dialect, matching how the rest of the connector routes queries.
+- **Lineage parser: rows without a table name reaching the DB** [#31524](https://github.com/open-metadata/OpenMetadata/pull/31524): Parsed table references with no table name are now skipped rather than persisted as broken rows.
+- **Ingestion sessions asserting on connection release** [#31535](https://github.com/open-metadata/OpenMetadata/pull/31535): `AUTOCOMMIT` is now set through `create_engine`, avoiding a SQLAlchemy assertion when a connection is released.
+
+### 📊 Data Quality
+
+- **Data Diff: Azure SQL connection parameters not propagated** [#31082](https://github.com/open-metadata/OpenMetadata/pull/31082): Azure SQL connection parameters are now passed through to Data Diff runs.
+- **Data Diff: special characters in datadiff usernames not decoded** [#31134](https://github.com/open-metadata/OpenMetadata/pull/31134): Usernames with special characters are decoded before being passed to the diff engine.
+- **Data Diff: Table Diff broken on Databricks, Unity Catalog, and Azure SQL** [#31713](https://github.com/open-metadata/OpenMetadata/pull/31713): Restores Table Diff support across all three dialects.
+
+### 🔍 Search & Discovery
+
+- **Reindex OOM under AutoTune and `ingestion_pipeline` field explosion** [#31117](https://github.com/open-metadata/OpenMetadata/pull/31117): Bounds AutoTune reindex memory and stops the `ingestion_pipeline` mapping from ballooning with dynamic fields.
+- **Domain not inherited through multi-level ancestors on batch/reindex** [#31365](https://github.com/open-metadata/OpenMetadata/pull/31365): Domain inheritance now walks the full ancestor chain during batch reindex.
+- **Inherited domain lost on descendants when an asset is moved** [#31417](https://github.com/open-metadata/OpenMetadata/pull/31417): Moving an asset now propagates the inherited domain to all descendants in search.
+- **Column search counts not matching results** [#31207](https://github.com/open-metadata/OpenMetadata/pull/31207): Column search is now routed through the structured query builder, so aggregated counts match the returned hits.
+- **Search connection pool starvation** [#31705](https://github.com/open-metadata/OpenMetadata/pull/31705): Bounds `httpclient5` connection-request timeouts and disables transport compression, preventing the search client from starving under load.
+- **KNN leg not scoped by `dataProducts`** [#30962](https://github.com/open-metadata/OpenMetadata/pull/30962): KNN queries now honour the `dataProducts` scope, matching the lexical leg.
+- **Deleted entities appearing in the search config preview** [#31151](https://github.com/open-metadata/OpenMetadata/pull/31151): Soft-deleted entities are excluded from the preview shown when editing search settings.
+- **Missing `entity_usage` index for percentile lookups** [#30032](https://github.com/open-metadata/OpenMetadata/pull/30032): Adds an index that speeds up `compute.percentile` on large usage datasets.
+- **Related-entity rows pointing at columns break the context center** [#31360](https://github.com/open-metadata/OpenMetadata/pull/31360): Ships a 1.13.4 migration that drops orphan column-targeted related-entity rows.
+
+### 🛡️ Data Governance & Quality
+
+- **Governance workflows stalling on migration DataSource** [#30650](https://github.com/open-metadata/OpenMetadata/pull/30650): Pools Flowable's migration DataSource so it stops opening a fresh connection per command, unblocking workflow migrations on busy databases.
+- **Workflow polling too aggressive on 1.13** [#31322](https://github.com/open-metadata/OpenMetadata/pull/31322): Reduces workflow polling frequency to cut database and event-consumer pressure.
+- **Null `businessKey` race + noisy Flowable logs** (backport of #31017): Eliminates a race that could produce workflow instances with a null business key and silences non-OpenMetadata Flowable log noise.
+- **Task conditions ignored on per-entity task permissions** [#30851](https://github.com/open-metadata/OpenMetadata/pull/30851): Task conditions are now evaluated when computing per-entity task permissions (initial attempt was reverted; final fix is included).
+- **Read authorization depending on the requested fields projection** [#30691](https://github.com/open-metadata/OpenMetadata/pull/30691): Read authorization is now independent of the `fields` query parameter, closing a projection-based bypass.
+- **Alerts: destination config leaking in `testDestination` response** [#31634](https://github.com/open-metadata/OpenMetadata/pull/31634): Destination configuration is now redacted from the `testDestination` API response.
+- **Orphan test case 404s the whole test case listing** [#31380](https://github.com/open-metadata/OpenMetadata/pull/31380): A single stale test case no longer breaks paginated test-case listings.
+- **Data Product ports: non-data-asset entities and bad `tableColumn` rows** [#30186](https://github.com/open-metadata/OpenMetadata/pull/30186): Non-data-asset entities are rejected as ports, and existing bad `tableColumn` port rows are dropped.
+- **Tags: `disabled` flag inherited from a Classification getting persisted on tags** [#30821](https://github.com/open-metadata/OpenMetadata/pull/30821): The inherited `disabled` state is no longer written back onto the tag entity.
+- **Ingestion PUT clobbering the tag recognizer config** [#31304](https://github.com/open-metadata/OpenMetadata/pull/31304): Tag recognizer configuration is preserved across ingestion `PUT`s.
+- **Seeded tags drift on startup** [#31460](https://github.com/open-metadata/OpenMetadata/pull/31460): Seeded tags are reconciled on service startup so they stay in sync with the shipped defaults.
+- **Any-language recognizer normalization** [#31546](https://github.com/open-metadata/OpenMetadata/pull/31546): Backports normalization so recognizers behave consistently regardless of source language.
+
+### 🔗 Lineage
+
+- **Column-level lineage: removing an edge dropped the wrong column pair** [#31107](https://github.com/open-metadata/OpenMetadata/pull/31107): Removing a column-level edge now drops exactly the column pair that was removed.
+- **Ontology Explorer: unhandled G6 rejections after graph destroy** [#31293](https://github.com/open-metadata/OpenMetadata/pull/31293): Late `draw()` promises from a destroyed G6 graph are now handled, preventing UI crashes on tab switch.
+
+### 🤖 MCP Server
+
+- **MCP Server config tab not wired to the settings the server reads** [#30620](https://github.com/open-metadata/OpenMetadata/pull/30620): The configuration tab now edits the same settings the MCP server actually consumes.
+- **`create_lineage` not marked destructive** [#30745](https://github.com/open-metadata/OpenMetadata/pull/30745): The `create_lineage` tool is now flagged as destructive so MCP clients can prompt appropriately.
+- **CORS headers, unused capability, OAuth `iss` parameter** [#30674](https://github.com/open-metadata/OpenMetadata/pull/30674): Fixes MCP CORS headers, removes the unused resources capability, and populates the OAuth `iss` parameter.
+- **Null `protected_resource_metadata` in the discovery response** [#30643](https://github.com/open-metadata/OpenMetadata/pull/30643): Omits the field entirely when unset instead of returning `null`.
+- **Create tools can't set custom properties** [#31526](https://github.com/open-metadata/OpenMetadata/pull/31526): MCP create tools now accept custom-property values on entity creation.
+
+### 🔐 Authentication
+
+- **OIDC confidential login loop on session loss** [#31183](https://github.com/open-metadata/OpenMetadata/pull/31183): Losing the session no longer traps the OIDC confidential flow in a redirect loop.
+- **SSO login hotfix** [#31573](https://github.com/open-metadata/OpenMetadata/pull/31573): Cherry-picks the 1.13 SSO login fix from main.
+
+### ⚙️ Platform
+
+- **`O(N²)` in the entity history pagination endpoint** [#30728](https://github.com/open-metadata/OpenMetadata/pull/30728): Pagination is now linear, cutting response time on entities with long history.
+- **Async delete failures only surfaced over websocket** [#31319](https://github.com/open-metadata/OpenMetadata/pull/31319): Failures are now logged server-side in addition to the websocket notification so they show up in operator log searches.
+- **Recursive delete not routed through the bulk subtree path** [#31318](https://github.com/open-metadata/OpenMetadata/pull/31318): Recursive delete now dispatches to the bulk subtree implementation, avoiding per-entity round-trips.
+- **`/metadata/types/customProperties` returning non-custom properties** [#31172](https://github.com/open-metadata/OpenMetadata/pull/31172): The endpoint now returns only custom properties, matching its name.
+- **Container re-parenting via PATCH** [#28201](https://github.com/open-metadata/OpenMetadata/pull/28201): Containers can now be re-parented through PATCH like other hierarchical assets.
+- **Data Product reference indexing** [#30963](https://github.com/open-metadata/OpenMetadata/pull/30963): Backports the Data Product reference indexing fix so search stays consistent after linked-entity updates.
+
+### 🎛️ UI
+
+- **Landing page widgets pointing at removed routes** [#30658](https://github.com/open-metadata/OpenMetadata/pull/30658): Widgets are re-pointed at routes that still exist post-1.13.
+- **Intake forms: create-form custom-property rendering, drawer footer shift, `formFields` list** [#30726](https://github.com/open-metadata/OpenMetadata/pull/30726), [#30776](https://github.com/open-metadata/OpenMetadata/pull/30776), [#30817](https://github.com/open-metadata/OpenMetadata/pull/30817): Ports the 1.13.3 backend `formFields` work to the UI, stabilizes the drawer footer during checkbox toggles, and shows every field in the intake forms list.
+- **Column Bulk Operations: soft-deleted entities appearing; tag/glossary dropdown clicks swallowed by the drawer** [#30433](https://github.com/open-metadata/OpenMetadata/pull/30433), [#30634](https://github.com/open-metadata/OpenMetadata/pull/30634): Soft-deleted entities are excluded from the column grid and the tag/glossary dropdowns render inside the drawer so options are selectable.
+- **Table and entity-reference values not updating after edit** [#30781](https://github.com/open-metadata/OpenMetadata/pull/30781): Edits to table and entity-reference custom-property values now round-trip correctly.
+- **Delete modal messages wrapping awkwardly** [#30725](https://github.com/open-metadata/OpenMetadata/pull/30725): Long asset names no longer break the layout of the delete confirmation modal.
+- **Default icon for applications with no logo** [#30761](https://github.com/open-metadata/OpenMetadata/pull/30761): Applications missing a logo now render a default icon instead of a broken image.
+- **Related terms `+N` badge not expandable** [#31010](https://github.com/open-metadata/OpenMetadata/pull/31010): The `+N` badge on glossary related terms is now clickable to reveal the full list.
+- **Activity feed and announcement bodies stuck on the loading spinner** [#31234](https://github.com/open-metadata/OpenMetadata/pull/31234): Feed and announcement bodies now render once their payload arrives.
+- **Team quick-info popover on entity owner chips** [#31226](https://github.com/open-metadata/OpenMetadata/pull/31226): Hovering a team owner chip surfaces a quick-info popover with team details.
+- **Edit Classification from the manage button + Tag Auto-Classification gating** [#31299](https://github.com/open-metadata/OpenMetadata/pull/31299): Classifications can now be edited from the manage menu, and the Tag Auto-Classification toggle is gated behind the right permission.
+- **Data Products: certification quick filter, remove Lifecycle Stage filter, style/modal error handling** [#31743](https://github.com/open-metadata/OpenMetadata/pull/31743), [#31703](https://github.com/open-metadata/OpenMetadata/pull/31703), [#31714](https://github.com/open-metadata/OpenMetadata/pull/31714): Adds a Certification quick filter, removes the stale Lifecycle Stage filter, and catches unhandled rejections in the style save and metadata modal.
+- **Tag color styling missing on Data Product and Domain pages** [#31804](https://github.com/open-metadata/OpenMetadata/pull/31804): Tag colors now render consistently on Data Product and Domain detail pages.
+- **Glossary left panel duplicating the last page; unhandled rejection on entity switch** [#30975](https://github.com/open-metadata/OpenMetadata/pull/30975), [#31711](https://github.com/open-metadata/OpenMetadata/pull/31711): Fixes the duplicate page in the glossary tree and swallows the initialization error that fired when switching entities.
+- **Teams: soft-deleted members counted in `userCount`** [#31663](https://github.com/open-metadata/OpenMetadata/pull/31663): Soft-deleted users are excluded from the team user count.
+- **Inherited team persona shown as the user default** [#30278](https://github.com/open-metadata/OpenMetadata/pull/30278): The inherited persona is no longer misrepresented as the user's default.
+- **Queries tab: badge count skeleton while loading** [#31689](https://github.com/open-metadata/OpenMetadata/pull/31689): The Queries tab now shows a skeleton in the badge while the count fetches, instead of flashing `0`.
+- **Query Tab UI backend integration** [#30690](https://github.com/open-metadata/OpenMetadata/pull/30690): Updates the UI-side backend calls for the Query Tab to match the current API surface.
+- **Grid focus lost after `execCommand('copy')` in bulk import** [#30825](https://github.com/open-metadata/OpenMetadata/pull/30825): Focus is restored to the grid after copy, and the bulk-import clipboard mock is made effective.
+- **Bulk import spec fixes** [#30746](https://github.com/open-metadata/OpenMetadata/pull/30746): Aligns the bulk import spec with the current UI flow.
+- **Lazy loading rolled out across Data Quality, Incident Manager, Activity Feed, Announcements, Domain, Glossary, common pages, Explore, Alerts, Database/Schema/Container pages, Services Lineage, Data Insights** [#31037](https://github.com/open-metadata/OpenMetadata/pull/31037)–[#31048](https://github.com/open-metadata/OpenMetadata/pull/31048): Ports the tab and heavy-component lazy-loading foundation to 1.13, meaningfully reducing initial bundle sizes across most detail pages.
+- **Login: video animation on the Collate login side** [#31396](https://github.com/open-metadata/OpenMetadata/pull/31396).
+
+### 🔒 Security
+
+- **Ingestion base image rebased onto Debian 13 (–60% CVEs)** [#31353](https://github.com/open-metadata/OpenMetadata/pull/31353).
+- **Ingestion images moved to Python 3.12; build tooling dropped; datamodel-code-gen upgraded** [#30911](https://github.com/open-metadata/OpenMetadata/pull/30911).
+- **Cleared remaining ingestion image CVEs; cut Go and util-linux CVE surface** [#31338](https://github.com/open-metadata/OpenMetadata/pull/31338), [#31612](https://github.com/open-metadata/OpenMetadata/pull/31612).
+- **Hardened Python security boundaries in ingestion** [#31469](https://github.com/open-metadata/OpenMetadata/pull/31469).
+- **`libthrift` → 0.24.0** [#30670](https://github.com/open-metadata/OpenMetadata/pull/30670), [#30922](https://github.com/open-metadata/OpenMetadata/pull/30922).
+- **BouncyCastle → 1.85** to clear `bcprov-jdk18on` findings [#30913](https://github.com/open-metadata/OpenMetadata/pull/30913).
+- **`netty` → 4.1.137.Final** for CVE-2026-59903 [#31792](https://github.com/open-metadata/OpenMetadata/pull/31792).
+- **`c3p0` 0.12.0 → 0.14.1** for CVE-2026-55223 [#31458](https://github.com/open-metadata/OpenMetadata/pull/31458).
+- **`httpcore5` pinned to 5.4.3** for CVE-2026-54399 [#31513](https://github.com/open-metadata/OpenMetadata/pull/31513).
+- **`httpclient5` moved to 5.6.3, transport-level content compression disabled** [#31667](https://github.com/open-metadata/OpenMetadata/pull/31667).
+- **`sqlparse` forced to 0.6.0 in the ingestion operator images** to clear 4 CVEs [#31791](https://github.com/open-metadata/OpenMetadata/pull/31791).
+- **UI dependency vulnerabilities** (`socket.io-parser`, `postcss`, `undici`) [#30970](https://github.com/open-metadata/OpenMetadata/pull/30970).
+- **Transitive CVE dependency bumps** [#31605](https://github.com/open-metadata/OpenMetadata/pull/31605).
+- **Natural Language Search config no longer exposed in OpenMetadata OSS** [#31419](https://github.com/open-metadata/OpenMetadata/pull/31419).
+
+### 📣 Notifications
+
+- **MS Teams: URL-only code spans not clickable** [#31695](https://github.com/open-metadata/OpenMetadata/pull/31695): URL-only code spans in MS Teams notification templates are now linkified.

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "v1.13.4",
+    "date": "Released on 21st August 2026.",
+    "hasFeatures": false
+  },
+  {
     "version": "v1.13.3",
     "date": "Released on 31st July 2026.",
     "hasFeatures": false


### PR DESCRIPTION
## Summary

- Adds `content/product-updates/v1.13.4.md` — a curated changelog for OpenMetadata 1.13.4 covering ~190 commits since 1.13.3, grouped into Connectors & Ingestion, Data Quality, Search & Discovery, Data Governance & Quality, Lineage, MCP Server, Authentication, Platform, UI, Security, and Notifications.
- Prepends the v1.13.4 entry to `content/product-updates/versions.json`.
- Adds `.claude/skills/prep-product-update/SKILL.md`, a project-scoped skill that generates future release pages from a GitHub release URL, encoding the site's tone, grouping, and filtering rules.

## Test plan

- [ ] Local dev build renders `/product-updates#v1.13.4-changelog` correctly.
- [ ] Section emoji headings match `content/product-updates/README.md` conventions.
- [ ] PR links resolve to real merged PRs on open-metadata/OpenMetadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)