### PR TITLE
feat: add release notes for OpenMetadata v2.0.0

### DIFF
--- a/content/product-updates/v2.0.0.md
+++ b/content/product-updates/v2.0.0.md
@@ -30,7 +30,7 @@ Activity Feed, Tasks, Workflows, and Announcements are fully compatible with 2.0
 ### Ingestion — Connectors
 
 - **Databricks Pipeline**: Authentication updated from a bare `token` field to a structured `authType` object supporting Personal Access Token, DatabricksOAuth, and Azure AD. Stored connection configs are migrated automatically.
-- **Python 3.12**: Ingestion images now run on Python 3.12 (`python:3.12-slim-bookworm`). Custom ingestion images or Airflow environments pinned to Python 3.10 must be rebuilt — `cp310` wheels will not load.
+- **Python 3.12**: Ingestion images now run on Python 3.12 (`python:3.12-slim-trixie`). Custom ingestion images or Airflow environments pinned to Python 3.10 must be rebuilt — `cp310` wheels will not load.
 - Additional connector stability improvements and bug fixes across the connector library.
 
 ### MCP (Model Context Protocol)
@@ -55,45 +55,6 @@ The landing page has been redesigned with an updated navigation structure and cl
 ---
 
 ## Breaking Changes
-
-### Configuration — `naturalLanguageSearch` Simplified
-
-The `naturalLanguageSearch` configuration block has been simplified. LLM provider credentials, model IDs, and embedding settings have been removed from this block. The default `providerClass` has changed to the no-op implementation.
-
-**Before (1.13):**
-```yaml
-naturalLanguageSearch:
-  enabled: ${NATURAL_LANGUAGE_SEARCH_ENABLED:-true}
-  semanticSearchEnabled: ${SEMANTIC_SEARCH_ENABLED:-true}
-  embeddingProvider: ${EMBEDDING_PROVIDER:-bedrock}
-  maxConcurrentRequests: ${MAX_CONCURRENT_EMBEDDING_REQUESTS:-10}
-  providerClass: ${NATURAL_LANGUAGE_SEARCH_PROVIDER_CLASS:-io.collate.search.nlq.BedrockNLQService}
-  filterExtractor:
-    cacheMaxSize: ${COLLATE_NLQ_CACHE_MAX_SIZE:-1000}
-    cacheExpiryMinutes: ${COLLATE_NLQ_CACHE_EXPIRY_MINUTES:-5}
-    maxSampleValues: ${COLLATE_NLQ_MAX_SAMPLE_VALUES:-10}
-```
-
-**After (2.0):**
-```yaml
-naturalLanguageSearch:
-  enabled: ${NATURAL_LANGUAGE_SEARCH_ENABLED:-true}
-  semanticSearchEnabled: ${SEMANTIC_SEARCH_ENABLED:-true}
-  providerClass: ${NATURAL_LANGUAGE_SEARCH_PROVIDER_CLASS:-org.openmetadata.service.search.nlq.NoOpNLQService}
-  filterExtractor:
-    cacheMaxSize: ${COLLATE_NLQ_CACHE_MAX_SIZE:-1000}
-    cacheExpiryMinutes: ${COLLATE_NLQ_CACHE_EXPIRY_MINUTES:-5}
-    maxSampleValues: ${COLLATE_NLQ_MAX_SAMPLE_VALUES:-10}
-    maxTokens: ${COLLATE_NLQ_MAX_TOKENS:-256}
-    temperature: ${COLLATE_NLQ_TEMPERATURE:-0.0}
-    timeoutSeconds: ${COLLATE_NLQ_TIMEOUT_SECONDS:-15}
-```
-
-The `filterExtractor` gains three new fields (`maxTokens`, `temperature`, `timeoutSeconds`) previously scattered across provider-specific sub-blocks.
-
-**Action required:** Remove provider credential fields (model IDs, API keys, embedding settings) from `naturalLanguageSearch`. If you were customising `providerClass`, update it to a 2.0-compatible implementation.
-
----
 
 ### MCP — `nextCursor` Pagination
 
@@ -152,7 +113,7 @@ connection:
 
 ### Ingestion Images — Python 3.12
 
-Ingestion images have moved from Python 3.10 to **Python 3.12** (`python:3.12-slim-bookworm`; Airflow upgraded to `apache/airflow:3.2.2-python3.12`).
+Ingestion images have moved from Python 3.10 to **Python 3.12** (`python:3.12-slim-trixie`; Airflow upgraded to `apache/airflow:3.3.0-python3.12`).
 
 **Action required:**
 - Rebuild any custom ingestion Docker images against Python 3.12.
@@ -207,7 +168,6 @@ Support for Great Expectations 0.x has been **removed** in 2.0. **Action require
 
 | Area | Action Required |
 |---|---|
-| YAML config | Simplify `naturalLanguageSearch` block — remove provider credential fields; update `providerClass` if customised |
 | MCP clients | Update offset-based paging to use the `nextCursor` contract |
 | Alerts | After upgrade, widen or remove filters if entity-scoped alerts go quiet |
 | Profiler config | Explicitly add cardinality distribution if downstream features depend on it |

--- a/content/product-updates/v2.0.0.md
+++ b/content/product-updates/v2.0.0.md
@@ -56,6 +56,55 @@ MCP read tools now return a `nextCursor` value in every response. Clients that p
 
 The existing `from` and `size` offset parameters **continue to work** — the cursor only takes effect when explicitly passed. No migration is required for existing MCP clients.
 
+### Semantic Search — Embedding Configuration Moved
+
+Embedding settings have moved out of `naturalLanguageSearch` into a new top-level `llmConfiguration.embeddings` block. Semantic search stops working silently on upgrade unless the new block is configured and enabled.
+
+**Before (1.13):**
+```yaml
+naturalLanguageSearch:
+  enabled: ${NATURAL_LANGUAGE_SEARCH_ENABLED:-true}
+  semanticSearchEnabled: ${SEMANTIC_SEARCH_ENABLED:-true}
+  embeddingProvider: ${EMBEDDING_PROVIDER:-bedrock}
+  maxConcurrentRequests: ${MAX_CONCURRENT_EMBEDDING_REQUESTS:-10}
+  bedrock:
+    awsConfig:
+      region: ${AWS_DEFAULT_REGION:-""}
+      accessKeyId: ${AWS_ACCESS_KEY_ID:-""}
+      secretAccessKey: ${AWS_SECRET_ACCESS_KEY:-""}
+    embeddingModelId: ${AWS_BEDROCK_EMBED_MODEL_ID:-"amazon.titan-embed-text-v2:0"}
+    embeddingDimension: ${AWS_BEDROCK_EMBEDDING_DIMENSION:-512}
+```
+
+**After (2.0):**
+```yaml
+naturalLanguageSearch:
+  enabled: ${NATURAL_LANGUAGE_SEARCH_ENABLED:-true}
+  semanticSearchEnabled: ${SEMANTIC_SEARCH_ENABLED:-true}
+  providerClass: ${NATURAL_LANGUAGE_SEARCH_PROVIDER_CLASS:-org.openmetadata.service.search.nlq.NoOpNLQService}
+
+llmConfiguration:
+  enabled: ${LLM_ENABLED:-false}
+  provider: ${LLM_PROVIDER:-bedrock}   # noop | openai | azureOpenAI | bedrock | google | anthropic
+  embeddings:
+    provider: ${EMBEDDING_PROVIDER:-bedrock}
+    maxConcurrentRequests: ${MAX_CONCURRENT_EMBEDDING_REQUESTS:-10}
+    bedrock:
+      awsConfig:
+        region: ${AWS_DEFAULT_REGION:-""}
+        accessKeyId: ${AWS_ACCESS_KEY_ID:-""}
+        secretAccessKey: ${AWS_SECRET_ACCESS_KEY:-""}
+      embeddingModelId: ${AWS_BEDROCK_EMBED_MODEL_ID:-"amazon.titan-embed-text-v2:0"}
+      embeddingDimension: ${AWS_BEDROCK_EMBEDDING_DIMENSION:-512}
+```
+
+**Action required:**
+1. Remove `embeddingProvider`, `maxConcurrentRequests`, and the provider sub-blocks from `naturalLanguageSearch`.
+2. Add the `llmConfiguration` block above with your provider settings under `llmConfiguration.embeddings`.
+3. Set `LLM_ENABLED=true` and `LLM_PROVIDER=<your-provider>` — embeddings remain off until both are set.
+
+Environment variables `EMBEDDING_PROVIDER`, `MAX_CONCURRENT_EMBEDDING_REQUESTS`, `AWS_BEDROCK_EMBED_MODEL_ID`, and `AWS_BEDROCK_EMBEDDING_DIMENSION` are **unchanged**.
+
 ### Profiler — Default Sampling Change
 
 The Profiler now defaults to **Dynamic Sampling** instead of scanning 100% of rows. Cardinality distribution metrics are **no longer collected by default**.
@@ -127,6 +176,21 @@ Support for Great Expectations 0.x has been **removed** in 2.0.
 ### Airflow as Internal Orchestrator — Deprecated in 2.1
 
 Airflow will be deprecated as the **internal** orchestration system in 2.1, in favour of the native Kubernetes Orchestrator introduced in 1.12. External Airflow installations are unaffected. Begin evaluating the Kubernetes Orchestrator now — documentation and migration guides will be published ahead of the 2.1 release.
+
+## Upgrade Actions Summary
+
+| Area | Action Required |
+|---|---|
+| MCP clients | No migration required — pass `cursor` for stable paging; `from`/`size` offset still works |
+| Semantic search / embeddings | Move embedding config from `naturalLanguageSearch` to `llmConfiguration.embeddings`; set `LLM_ENABLED=true` and `LLM_PROVIDER=<provider>` |
+| Profiler config | Explicitly add cardinality distribution if downstream features depend on it |
+| Databricks YAML | Update `token: dapi...` to `authType: { token: dapi... }` in external pipeline YAMLs |
+| Custom ingestion images | Rebuild against `python:3.12-slim-trixie`; remove `cp310` wheels. Skip if upgrading from 1.13.4. |
+| Chrome plugin | Set `additionalTrustedRedirectUris` to the full Chrome callback URI (e.g. `https://<extension-id>.chromiumapp.org/auth0`) |
+| Knowledge Center links | Update bookmarks and internal links to Context Center → Articles |
+| Great Expectations | Migrate from 0.x to `~=1.3` before upgrading |
+
+**[View the full changelog](https://github.com/open-metadata/OpenMetadata/compare/1.13.4-release...2.0.0-release)**
 
 ## Changelog
 

--- a/content/product-updates/v2.0.0.md
+++ b/content/product-updates/v2.0.0.md
@@ -1,0 +1,220 @@
+---
+id: 122
+version: v2.0.0
+date: Released on 24th August 2026.
+---
+
+You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/2.0.0-release).
+
+## Features
+
+### Data Quality Revamp
+
+- **Dynamic Sampling by default**: The Profiler now defaults to Dynamic Sampling instead of scanning 100% of rows, significantly reducing query cost and execution time on large tables.
+- **Cardinality distribution removed from defaults**: Cardinality metrics are no longer collected on every run. If your workflows depend on distinct-value counts (classification, tagging, custom rules), explicitly add cardinality distribution to the relevant profiler configuration.
+- Existing profiler configs are preserved — only pipelines using the default agent config are affected.
+
+### Governance — Custom Intake Forms & Owl Import
+
+- **Custom Intake Forms**: Define custom forms for governance intake workflows — asset certification, ownership assignment, data classification, or any structured intake process. Forms are configurable per entity type and feed into the existing task and workflow system.
+- **Owl Import**: Import OWL (Web Ontology Language) files to load existing ontologies and classification taxonomies directly into OpenMetadata, reusing industry-standard or enterprise-specific taxonomy assets.
+
+### Context Center
+
+Knowledge Center has been replaced by **Context Center** — the single destination for reference content in your catalog. Existing pages are automatically migrated as **Articles** on upgrade. New content types include **Documents** (freeform rich-text attached to assets or teams) and a **Dashboard view** for discovering and managing content across your organisation.
+
+### Activity Feed, Tasks, Workflows, and Announcements
+
+Activity Feed, Tasks, Workflows, and Announcements are fully compatible with 2.0 data models. Migrated assets, in-flight tasks, and announcements carry over automatically — no manual action required.
+
+### Ingestion — Connectors
+
+- **Databricks Pipeline**: Authentication updated from a bare `token` field to a structured `authType` object supporting Personal Access Token, DatabricksOAuth, and Azure AD. Stored connection configs are migrated automatically.
+- **Python 3.12**: Ingestion images now run on Python 3.12 (`python:3.12-slim-bookworm`). Custom ingestion images or Airflow environments pinned to Python 3.10 must be rebuilt — `cp310` wheels will not load.
+- Additional connector stability improvements and bug fixes across the connector library.
+
+### MCP (Model Context Protocol)
+
+OpenMetadata's MCP server exposes catalog metadata to AI assistants and agents through the Model Context Protocol — any MCP-compatible client (Claude, Cursor, IDE plugins) can query your catalog without custom integrations.
+
+- **Enabled by default**: Starts ready on upgrade; no manual activation needed.
+- **`nextCursor` pagination**: Read tools now use cursor-based paging instead of numeric offsets, preventing skipped results under concurrent writes (see Breaking Changes).
+
+### SCIM Provisioning
+
+SCIM Provisioning configuration has moved to **Settings → Team and Users → Provisioning**. The feature and all existing SCIM configurations are unaffected — only the navigation path changes.
+
+### Inbox
+
+Inbox notifications have been updated to reduce noise across 2.0 workflows — task notifications are grouped and filtered consistently, announcements are correctly scoped to relevant entities, and activity items from the 2.0 migration are correctly attributed.
+
+### Landing Page
+
+The landing page has been redesigned with an updated navigation structure and cleaner entry points into asset discovery, lineage, governance, and data quality — reducing the clicks required to reach the most-used workflows.
+
+---
+
+## Breaking Changes
+
+### Configuration — `naturalLanguageSearch` Simplified
+
+The `naturalLanguageSearch` configuration block has been simplified. LLM provider credentials, model IDs, and embedding settings have been removed from this block. The default `providerClass` has changed to the no-op implementation.
+
+**Before (1.13):**
+```yaml
+naturalLanguageSearch:
+  enabled: ${NATURAL_LANGUAGE_SEARCH_ENABLED:-true}
+  semanticSearchEnabled: ${SEMANTIC_SEARCH_ENABLED:-true}
+  embeddingProvider: ${EMBEDDING_PROVIDER:-bedrock}
+  maxConcurrentRequests: ${MAX_CONCURRENT_EMBEDDING_REQUESTS:-10}
+  providerClass: ${NATURAL_LANGUAGE_SEARCH_PROVIDER_CLASS:-io.collate.search.nlq.BedrockNLQService}
+  filterExtractor:
+    cacheMaxSize: ${COLLATE_NLQ_CACHE_MAX_SIZE:-1000}
+    cacheExpiryMinutes: ${COLLATE_NLQ_CACHE_EXPIRY_MINUTES:-5}
+    maxSampleValues: ${COLLATE_NLQ_MAX_SAMPLE_VALUES:-10}
+```
+
+**After (2.0):**
+```yaml
+naturalLanguageSearch:
+  enabled: ${NATURAL_LANGUAGE_SEARCH_ENABLED:-true}
+  semanticSearchEnabled: ${SEMANTIC_SEARCH_ENABLED:-true}
+  providerClass: ${NATURAL_LANGUAGE_SEARCH_PROVIDER_CLASS:-org.openmetadata.service.search.nlq.NoOpNLQService}
+  filterExtractor:
+    cacheMaxSize: ${COLLATE_NLQ_CACHE_MAX_SIZE:-1000}
+    cacheExpiryMinutes: ${COLLATE_NLQ_CACHE_EXPIRY_MINUTES:-5}
+    maxSampleValues: ${COLLATE_NLQ_MAX_SAMPLE_VALUES:-10}
+    maxTokens: ${COLLATE_NLQ_MAX_TOKENS:-256}
+    temperature: ${COLLATE_NLQ_TEMPERATURE:-0.0}
+    timeoutSeconds: ${COLLATE_NLQ_TIMEOUT_SECONDS:-15}
+```
+
+The `filterExtractor` gains three new fields (`maxTokens`, `temperature`, `timeoutSeconds`) previously scattered across provider-specific sub-blocks.
+
+**Action required:** Remove provider credential fields (model IDs, API keys, embedding settings) from `naturalLanguageSearch`. If you were customising `providerClass`, update it to a 2.0-compatible implementation.
+
+---
+
+### MCP — `nextCursor` Pagination
+
+MCP read tools have moved from offset-based paging to a **`nextCursor`** contract. Offset paging (`from: N, size: M`) is no longer supported on these tools.
+
+**Before:** Clients passed a numeric `from` offset alongside `size` to walk through results.
+
+**After:** Each response includes a `nextCursor` string. Pass this value as `cursor` on the next call. When `nextCursor` is absent or `null`, the result set is exhausted.
+
+**Action required:** Update any MCP client that pages results by numeric offset. Clients that only read the first page are unaffected.
+
+---
+
+### Alerts — Conversation Scoping Fixed
+
+Alert filters (Entity FQN, Owner, Domain, Entity Id, Source) now apply correctly to conversations and replies. Previously, an alert scoped to a specific entity received conversation notifications from every entity in the catalog.
+
+**Action required:** No migration needed. If an alert goes quiet after upgrading, check whether its filter is now too narrow — widen or remove filters that were previously being ignored.
+
+---
+
+### Profiler — Default Sampling Change
+
+The Profiler now defaults to **Dynamic Sampling** instead of scanning 100% of rows. Cardinality distribution metrics are **no longer collected by default**.
+
+**Action required:** If any workflows depend on cardinality/distinct-value data — custom rules, classification agents, or analytics built on column-level distinct counts — explicitly add cardinality distribution to the affected profiler configuration.
+
+---
+
+### Connectors — Databricks Pipeline Auth
+
+The `databricksPipelineConnection` schema drops the top-level `token` string in favour of a structured `authType` object (Personal Access Token, DatabricksOAuth, or Azure AD).
+
+**Before (1.13):**
+```yaml
+connection:
+  config:
+    type: DatabricksPipeline
+    hostPort: adb-xxxx.azuredatabricks.net:443
+    token: dapi...
+```
+
+**After (2.0):**
+```yaml
+connection:
+  config:
+    type: DatabricksPipeline
+    hostPort: adb-xxxx.azuredatabricks.net:443
+    authType:
+      token: dapi...
+```
+
+**Action required:** Stored configs are migrated automatically. External YAML files (CI pipelines, custom configurations) must be updated manually.
+
+---
+
+### Ingestion Images — Python 3.12
+
+Ingestion images have moved from Python 3.10 to **Python 3.12** (`python:3.12-slim-bookworm`; Airflow upgraded to `apache/airflow:3.2.2-python3.12`).
+
+**Action required:**
+- Rebuild any custom ingestion Docker images against Python 3.12.
+- Remove or replace `cp310` binary wheels — they will fail to import on 3.12 images.
+- If running a custom Airflow environment, upgrade to the 3.12-based Airflow image.
+
+---
+
+### Chrome Plugin — Trusted Redirect URIs
+
+The Chrome plugin now requires trusted redirect URIs to be explicitly declared. Previously the plugin accepted redirects to any origin.
+
+**Action required:** Add your OpenMetadata instance origin(s) to `additionalTrustedRedirectUris`:
+
+```yaml
+additionalTrustedRedirectUris: ${AUTHENTICATION_ADDITIONAL_TRUSTED_REDIRECT_URIS:-[]}
+```
+
+If not set, the Chrome plugin login flow will fail with a redirect mismatch error.
+
+---
+
+### SCIM Provisioning — Moved
+
+SCIM Provisioning configuration has moved to **Settings → Team and Users → Provisioning**. No configuration data is lost; only the navigation path changes.
+
+---
+
+### Context Center — Knowledge Center Removed
+
+Knowledge Center no longer exists as a standalone section. All existing pages are automatically migrated to **Articles** inside Context Center on upgrade — no manual content migration is needed.
+
+Any hard-coded links or bookmarks to Knowledge Center URLs (e.g. `/knowledge-center/...`) will break after upgrade, as the URL structure has changed.
+
+**Action required:** Update any internal documentation, wikis, or automation that references Knowledge Center URLs to point to the equivalent Article in Context Center.
+
+---
+
+## Deprecation Notices
+
+### Airflow as Internal Orchestrator (Deprecated in 2.1)
+
+Airflow will be deprecated as the **internal** orchestration system in 2.1, in favour of the native Kubernetes Orchestrator introduced in 1.12. External Airflow installations are unaffected. Begin evaluating the Kubernetes Orchestrator now — documentation and migration guides will be published ahead of the 2.1 release.
+
+### Great Expectations 0.x
+
+Support for Great Expectations 0.x has been **removed** in 2.0. **Action required:** Migrate to Great Expectations 1.x before upgrading. See the [Great Expectations 1.x migration guide](https://docs.greatexpectations.io/docs/guides/miscellaneous/migration_guide).
+
+---
+
+## Upgrade Actions Summary
+
+| Area | Action Required |
+|---|---|
+| YAML config | Simplify `naturalLanguageSearch` block — remove provider credential fields; update `providerClass` if customised |
+| MCP clients | Update offset-based paging to use the `nextCursor` contract |
+| Alerts | After upgrade, widen or remove filters if entity-scoped alerts go quiet |
+| Profiler config | Explicitly add cardinality distribution if downstream features depend on it |
+| Databricks YAML | Update `token: dapi...` to `authType: { token: dapi... }` in external pipeline YAMLs |
+| Custom ingestion images | Rebuild against Python 3.12; remove `cp310` wheel dependencies |
+| Chrome plugin | Set `additionalTrustedRedirectUris` to your instance origin(s) |
+| Knowledge Center links | Update bookmarks and internal links to Context Center → Articles |
+| Great Expectations | Migrate from 0.x to 1.x before upgrading |
+
+**[View the full changelog](https://github.com/open-metadata/OpenMetadata/compare/1.13.4-release...2.0.0-release)**

--- a/content/product-updates/v2.0.0.md
+++ b/content/product-updates/v2.0.0.md
@@ -14,10 +14,10 @@ You can find the GitHub release [here](https://github.com/open-metadata/OpenMeta
 - **Cardinality distribution removed from defaults**: Cardinality metrics are no longer collected on every run. If your workflows depend on distinct-value counts (classification, tagging, custom rules), explicitly add cardinality distribution to the relevant profiler configuration.
 - Existing profiler configs are preserved — only pipelines using the default agent config are affected.
 
-### Governance — Custom Intake Forms & Owl Import
+### Governance — Custom Intake Forms & OWL Import
 
 - **Custom Intake Forms**: Define custom forms for governance intake workflows — asset certification, ownership assignment, data classification, or any structured intake process. Forms are configurable per entity type and feed into the existing task and workflow system.
-- **Owl Import**: Import OWL (Web Ontology Language) files to load existing ontologies and classification taxonomies directly into OpenMetadata, reusing industry-standard or enterprise-specific taxonomy assets.
+- **OWL Import**: Import OWL (Web Ontology Language) files to load existing ontologies and classification taxonomies directly into OpenMetadata, reusing industry-standard or enterprise-specific taxonomy assets.
 
 ### Context Center
 
@@ -30,7 +30,7 @@ Activity Feed, Tasks, Workflows, and Announcements are fully compatible with 2.0
 ### Ingestion — Connectors
 
 - **Databricks Pipeline**: Authentication updated from a bare `token` field to a structured `authType` object supporting Personal Access Token, DatabricksOAuth, and Azure AD. Stored connection configs are migrated automatically.
-- **Python 3.12**: Ingestion images now run on Python 3.12 (`python:3.12-slim-trixie`). Custom ingestion images or Airflow environments pinned to Python 3.10 must be rebuilt — `cp310` wheels will not load.
+- **Python 3.12**: Ingestion images now run on Python 3.12 (`python:3.12-slim-trixie`; Airflow upgraded to `apache/airflow:3.3.0-python3.12`). This change first shipped in 1.13.4 — skip if already on 1.13.4.
 - Additional connector stability improvements and bug fixes across the connector library.
 
 ### MCP (Model Context Protocol)
@@ -38,11 +38,7 @@ Activity Feed, Tasks, Workflows, and Announcements are fully compatible with 2.0
 OpenMetadata's MCP server exposes catalog metadata to AI assistants and agents through the Model Context Protocol — any MCP-compatible client (Claude, Cursor, IDE plugins) can query your catalog without custom integrations.
 
 - **Enabled by default**: Starts ready on upgrade; no manual activation needed.
-- **`nextCursor` pagination**: Read tools now use cursor-based paging instead of numeric offsets, preventing skipped results under concurrent writes (see Breaking Changes).
-
-### SCIM Provisioning
-
-SCIM Provisioning configuration has moved to **Settings → Team and Users → Provisioning**. The feature and all existing SCIM configurations are unaffected — only the navigation path changes.
+- **`nextCursor` pagination**: MCP read tools now return a `nextCursor` value alongside results. Pass `cursor` on subsequent calls for stable cursor-based paging. Existing `from`/`size` offset parameters continue to work.
 
 ### Inbox
 
@@ -52,37 +48,19 @@ Inbox notifications have been updated to reduce noise across 2.0 workflows — t
 
 The landing page has been redesigned with an updated navigation structure and cleaner entry points into asset discovery, lineage, governance, and data quality — reducing the clicks required to reach the most-used workflows.
 
----
-
 ## Breaking Changes
 
-### MCP — `nextCursor` Pagination
+### MCP — Cursor Paging Available (Offset Still Supported)
 
-MCP read tools have moved from offset-based paging to a **`nextCursor`** contract. Offset paging (`from: N, size: M`) is no longer supported on these tools.
+MCP read tools now return a `nextCursor` value in every response. Clients that pass `cursor` on the next call will use stable cursor-based paging, which avoids skipped results under concurrent writes.
 
-**Before:** Clients passed a numeric `from` offset alongside `size` to walk through results.
-
-**After:** Each response includes a `nextCursor` string. Pass this value as `cursor` on the next call. When `nextCursor` is absent or `null`, the result set is exhausted.
-
-**Action required:** Update any MCP client that pages results by numeric offset. Clients that only read the first page are unaffected.
-
----
-
-### Alerts — Conversation Scoping Fixed
-
-Alert filters (Entity FQN, Owner, Domain, Entity Id, Source) now apply correctly to conversations and replies. Previously, an alert scoped to a specific entity received conversation notifications from every entity in the catalog.
-
-**Action required:** No migration needed. If an alert goes quiet after upgrading, check whether its filter is now too narrow — widen or remove filters that were previously being ignored.
-
----
+The existing `from` and `size` offset parameters **continue to work** — the cursor only takes effect when explicitly passed. No migration is required for existing MCP clients.
 
 ### Profiler — Default Sampling Change
 
 The Profiler now defaults to **Dynamic Sampling** instead of scanning 100% of rows. Cardinality distribution metrics are **no longer collected by default**.
 
 **Action required:** If any workflows depend on cardinality/distinct-value data — custom rules, classification agents, or analytics built on column-level distinct counts — explicitly add cardinality distribution to the affected profiler configuration.
-
----
 
 ### Connectors — Databricks Pipeline Auth
 
@@ -109,8 +87,6 @@ connection:
 
 **Action required:** Stored configs are migrated automatically. External YAML files (CI pipelines, custom configurations) must be updated manually.
 
----
-
 ### Ingestion Images — Python 3.12
 
 Ingestion images have moved from Python 3.10 to **Python 3.12** (`python:3.12-slim-trixie`; Airflow upgraded to `apache/airflow:3.3.0-python3.12`).
@@ -120,27 +96,19 @@ Ingestion images have moved from Python 3.10 to **Python 3.12** (`python:3.12-sl
 - Remove or replace `cp310` binary wheels — they will fail to import on 3.12 images.
 - If running a custom Airflow environment, upgrade to the 3.12-based Airflow image.
 
----
+**Note:** This change first shipped in 1.13.4. If you are upgrading from 1.13.4, no action is needed.
 
 ### Chrome Plugin — Trusted Redirect URIs
 
 The Chrome plugin now requires trusted redirect URIs to be explicitly declared. Previously the plugin accepted redirects to any origin.
 
-**Action required:** Add your OpenMetadata instance origin(s) to `additionalTrustedRedirectUris`:
+**Action required:** `additionalTrustedRedirectUris` requires the **full redirect URI** — including scheme, host, port, and path. For the Chrome plugin, add the extension's callback URI:
 
 ```yaml
-additionalTrustedRedirectUris: ${AUTHENTICATION_ADDITIONAL_TRUSTED_REDIRECT_URIS:-[]}
+additionalTrustedRedirectUris: ["https://<your-extension-id>.chromiumapp.org/auth0"]
 ```
 
-If not set, the Chrome plugin login flow will fail with a redirect mismatch error.
-
----
-
-### SCIM Provisioning — Moved
-
-SCIM Provisioning configuration has moved to **Settings → Team and Users → Provisioning**. No configuration data is lost; only the navigation path changes.
-
----
+Replace `<your-extension-id>` with the actual Chrome extension ID. Setting only the origin will not satisfy the redirect check and the login flow will fail with a redirect mismatch error.
 
 ### Context Center — Knowledge Center Removed
 
@@ -150,31 +118,22 @@ Any hard-coded links or bookmarks to Knowledge Center URLs (e.g. `/knowledge-cen
 
 **Action required:** Update any internal documentation, wikis, or automation that references Knowledge Center URLs to point to the equivalent Article in Context Center.
 
----
+### Great Expectations 0.x — Support Removed
 
-## Deprecation Notices
+Support for Great Expectations 0.x has been **removed** in 2.0.
 
-### Airflow as Internal Orchestrator (Deprecated in 2.1)
+**Action required:** Migrate to Great Expectations `~=1.3` before upgrading. See the [Great Expectations migration guide](https://docs.greatexpectations.io/docs/guides/miscellaneous/migration_guide).
+
+### Airflow as Internal Orchestrator — Deprecated in 2.1
 
 Airflow will be deprecated as the **internal** orchestration system in 2.1, in favour of the native Kubernetes Orchestrator introduced in 1.12. External Airflow installations are unaffected. Begin evaluating the Kubernetes Orchestrator now — documentation and migration guides will be published ahead of the 2.1 release.
 
-### Great Expectations 0.x
+## Changelog
 
-Support for Great Expectations 0.x has been **removed** in 2.0. **Action required:** Migrate to Great Expectations 1.x before upgrading. See the [Great Expectations 1.x migration guide](https://docs.greatexpectations.io/docs/guides/miscellaneous/migration_guide).
+### Platform
 
----
+- SCIM Provisioning configuration has moved to **Settings → Team and Users → Provisioning**. No configuration data is lost; only the navigation path changes.
 
-## Upgrade Actions Summary
+### Alerts
 
-| Area | Action Required |
-|---|---|
-| MCP clients | Update offset-based paging to use the `nextCursor` contract |
-| Alerts | After upgrade, widen or remove filters if entity-scoped alerts go quiet |
-| Profiler config | Explicitly add cardinality distribution if downstream features depend on it |
-| Databricks YAML | Update `token: dapi...` to `authType: { token: dapi... }` in external pipeline YAMLs |
-| Custom ingestion images | Rebuild against Python 3.12; remove `cp310` wheel dependencies |
-| Chrome plugin | Set `additionalTrustedRedirectUris` to your instance origin(s) |
-| Knowledge Center links | Update bookmarks and internal links to Context Center → Articles |
-| Great Expectations | Migrate from 0.x to 1.x before upgrading |
-
-**[View the full changelog](https://github.com/open-metadata/OpenMetadata/compare/1.13.4-release...2.0.0-release)**
+- Fixed alert filters (Entity FQN, Owner, Domain, Entity Id, Source) not applying correctly to conversations and replies. Previously, an alert scoped to a specific entity received conversation notifications from every entity in the catalog. If an alert goes quiet after upgrading, widen or remove filters that were previously being ignored.

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "v2.0.0",
+    "date": "Released on 24th August 2026.",
+    "hasFeatures": true
+  },
+  {
     "version": "v1.13.4",
     "date": "Released on 21st August 2026.",
     "hasFeatures": false


### PR DESCRIPTION
Adds the v2.0.0 release notes page to the product updates section and registers it in the version registry.

The new `v2.0.0.md` covers: Features (Data Quality Revamp, Context Center, Governance intake forms, MCP, connectors), Breaking Changes (naturalLanguageSearch config, MCP nextCursor pagination, Profiler sampling, Databricks auth, Python 3.12, Chrome plugin redirect URIs, Knowledge Center removal), Deprecation Notices, and an Upgrade Actions Summary table. Version is dated 24th August 2026 and will automatically appear as the latest release in the UI via semantic version sorting.