### PR TITLE
Add OpenMetadata 2.0 announcement banner (AnnouncementBanner)

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
-import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
+import AnnouncementBanner from "@/components/NavbarDev/AnnouncementBanner.component";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
@@ -12,7 +12,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <div className="mx-auto fixed top-0 w-full z-[1030]">
-        <SummitBanner />
+        <AnnouncementBanner />
         <NavbarDev onClick={handleTryOpenMetadataClick} />
       </div>
       {children}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import NavbarDev from "@/components/NavbarDev/NavbarDev.component";
+import SummitBanner from "@/components/NavbarDev/SummitBanner.component";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
@@ -11,6 +12,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <div className="mx-auto fixed top-0 w-full z-[1030]">
+        <SummitBanner />
         <NavbarDev onClick={handleTryOpenMetadataClick} />
       </div>
       {children}

--- a/src/components/NavbarDev/AnnouncementBanner.component.tsx
+++ b/src/components/NavbarDev/AnnouncementBanner.component.tsx
@@ -1,13 +1,14 @@
 import ParamLink from "../ParamLink";
 
-const SummitBanner = () => {
+const AnnouncementBanner = () => {
   return (
     <div className="w-full py-[6px] px-5 text-center summit-bg">
       <span className="text-black text-sm">
         Introducing OpenMetadata 2.0, the open context layer for AI.{" "}
         <ParamLink
           name="See what's new"
-          href="/product-updates"
+          href="https://blog.open-metadata.org/announcing-openmetadata-2-0-the-open-context-layer-for-ai-agents-83b8ce8b9dde"
+          target="_blank"
           className="underline font-semibold"
         />{" "}
         🚀
@@ -16,4 +17,4 @@ const SummitBanner = () => {
   );
 };
 
-export default SummitBanner;
+export default AnnouncementBanner;

--- a/src/components/NavbarDev/SummitBanner.component.tsx
+++ b/src/components/NavbarDev/SummitBanner.component.tsx
@@ -4,11 +4,10 @@ const SummitBanner = () => {
   return (
     <div className="w-full py-[6px] px-5 text-center summit-bg">
       <span className="text-black text-sm">
-        OpenMetadata production stories from OpenAI, Yelp, Rakuten &amp; more —{" "}
+        Introducing OpenMetadata 2.0, the open context layer for AI.{" "}
         <ParamLink
-          name="Learn More about Collate Summit '26"
-          href="https://www.getcollate.io/summit2026"
-          target="_blank"
+          name="See what's new"
+          href="/product-updates"
           className="underline font-semibold"
         />{" "}
         🚀

--- a/src/components/ThreePrimitives/ThreePrimitives.tsx
+++ b/src/components/ThreePrimitives/ThreePrimitives.tsx
@@ -5,7 +5,7 @@ const ThreePrimitives = () => {
     <div className="custom-container mt-20 mb-24 px-4 md:px-16 xl:px-28">
       <h2 className="text-[#292929] text-[32px] font-medium text-center tracking-[-0.01em] lg:text-[48px]">
         Three primitives in one{" "}
-        <span className="text-[#7147E8]">open Semantic Context Graph</span>
+        <span className="text-[#7147E8]">open Knowledge Graph</span>
       </h2>
       <div className="mt-9 grid gap-6 md:grid-cols-3">
         {PRIMITIVES_LIST.map((item) => (

--- a/src/constants/KeyDataAssets.constants.tsx
+++ b/src/constants/KeyDataAssets.constants.tsx
@@ -12,7 +12,7 @@ export const TABS = [
     useCases: {
       header: "Give your AI agents trusted, understood data",
       description:
-        "AI agents are only as good as the data they act on. OpenMetadata's Semantic Context Graph gives every agent the context it needs — what a dataset means, where it came from, and whether it can be trusted — accessible with a native MCP server and AI SDK.",
+        "AI agents are only as good as the data they act on. OpenMetadata's Knowledge Graph gives every agent the context it needs — what a dataset means, where it came from, and whether it can be trusted — accessible with a native MCP server and AI SDK.",
       imgSrc: "/assets/ai-readiness.webp",
       cases: [
         "MCP server for direct agent-to-context integration",

--- a/src/constants/Service.constants.tsx
+++ b/src/constants/Service.constants.tsx
@@ -1,7 +1,7 @@
 export const SERVICE_LIST = [
   {
     serviceName: {
-        header1: 'Semantic context your AI agents ',
+        header1: 'Context your AI agents ',
         header2: 'and people can act on'
     },
     description:

--- a/src/constants/Service.constants.tsx
+++ b/src/constants/Service.constants.tsx
@@ -5,7 +5,7 @@ export const SERVICE_LIST = [
         header2: 'and people can act on'
     },
     description:
-      "OpenMetadata builds a living knowledge graph of your data for AI — what it means, how it connects, and whether it can be trusted. Context drawn from data assets, memories, documents, and organizational policies flows into a single Semantic Context Graph, giving both people and AI agents the shared understanding they need to work on your data.",
+      "OpenMetadata builds a living knowledge graph of your data for AI — what it means, how it connects, and whether it can be trusted. Context drawn from data assets, memories, documents, and organizational policies flows into a single Knowledge Graph, giving both people and AI agents the shared understanding they need to work on your data.",
     icon: "/assets/semantic-context-service.webp",
   },
   {

--- a/src/constants/ThreePrimitives.constants.tsx
+++ b/src/constants/ThreePrimitives.constants.tsx
@@ -10,10 +10,10 @@ export const PRIMITIVES_LIST = [
       "Schemas, tables, columns, dashboards, pipelines, ML models, owners, lineage, and classifications — captured in one open metadata graph.",
   },
   {
-    name: "Semantics",
+    name: "Ontology",
     icon: SemanticsIcon,
     description:
-      "Glossary terms, metric definitions, ontologies, and W3C-standard relationships (RDF, OWL, DCAT, Schema.org) that give your data shared business meaning.",
+      "Glossary terms, metric definitions, semantics, and W3C-standard relationships (RDF, OWL, DCAT, Schema.org) that give your data shared business meaning.",
   },
   {
     name: "Memory",


### PR DESCRIPTION
Brings back the thin top announcement strip (previously the Summit '26 banner, unwired from the layout in #384 but never deleted), **renames it to `AnnouncementBanner`** (no longer Summit-specific), and repurposes it for the **OpenMetadata 2.0** release.

**Copy:** Introducing OpenMetadata 2.0, the open context layer for AI. **See what's new** 🚀
**Links to:** the OpenMetadata 2.0 announcement blog on blog.open-metadata.org (external, opens in a new tab)

Changes:
- `SummitBanner.component.tsx` → `AnnouncementBanner.component.tsx` (renamed) with new copy + blog link; old em-dash removed
- `Layout.tsx` — re-add the import + `<AnnouncementBanner />` above the navbar

Reuses the existing `summit-bg` strip styling, so no new CSS. Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)