### PR TITLE
feat: add release notes for OpenMetadata v2.0.1

### DIFF
--- a/content/product-updates/v2.0.1.md
+++ b/content/product-updates/v2.0.1.md
@@ -1,0 +1,116 @@
+---
+id: 123
+version: v2.0.1
+date: Released on 2nd September 2026
+---
+
+## Changelog
+
+OpenMetadata 2.0.1 is a maintenance release focused on connector reliability, UI polish across Context Center and Explore, data governance and quality correctness, search and lineage fixes, MCP hardening, and a broad security dependency cleanup.
+
+### 🔌 Connectors & Ingestion
+
+- **MLflow: Unity Catalog model version resolution and search were broken** [#30856](https://github.com/open-metadata/OpenMetadata/pull/30856), [#31387](https://github.com/open-metadata/OpenMetadata/pull/31387): Model versions now resolve correctly, and the search filter is properly escaped.
+- **MLflow 3.x model signatures were not extracted and the registry listing was unpaginated** [#32093](https://github.com/open-metadata/OpenMetadata/pull/32093): Extracts 3.x model signatures and paginates the registry listing.
+- **BigQuery: GCP service account impersonation not applied to policy tag reads** [#31249](https://github.com/open-metadata/OpenMetadata/pull/31249): Policy tag reads now honour the configured impersonation, matching the rest of the connector.
+- **Tableau: mirrored upstream columns duplicated in data models** [#30928](https://github.com/open-metadata/OpenMetadata/pull/30928): Mirrored upstream columns are collapsed instead of appearing twice.
+- **DB2: sqlalchemy-ibmi dialect incompatible with SQLAlchemy 2.0** [#30731](https://github.com/open-metadata/OpenMetadata/pull/30731): Adapts the dialect so DB2 ingestion works on SQLAlchemy 2.0.
+- **DB2: CLI driver reinitialized on every query** [#32151](https://github.com/open-metadata/OpenMetadata/pull/32151): The driver now initializes once per process.
+- **Trino: unnamed and quoted ROW fields mishandled during reflection** [#31402](https://github.com/open-metadata/OpenMetadata/pull/31402): Reflection now correctly handles unnamed and quoted ROW fields.
+- **REST API: array-root schemas failed to parse** [#31698](https://github.com/open-metadata/OpenMetadata/pull/31698): Schemas with an array at the root now parse correctly.
+- **Glue: duplicate columns caused partition keys to drop the whole table** [#32105](https://github.com/open-metadata/OpenMetadata/pull/32105): Columns are deduplicated so partition keys no longer cause a full table drop.
+- **Glue: a custom databaseName dropped every schema** [#32399](https://github.com/open-metadata/OpenMetadata/pull/32399): Custom `databaseName` values no longer wipe out schema ingestion.
+- **OpenLineage: Kafka SSL and password handling was missing on 2.0** [#32089](https://github.com/open-metadata/OpenMetadata/pull/32089): Backports SSL and password handling for Kafka-backed OpenLineage events.
+- **dbt: results with a null message failed to ingest** [#31138](https://github.com/open-metadata/OpenMetadata/pull/31138): Null-message results now ingest, and compile-only stubs no longer shadow executed results.
+- **Doris: unofficial driver caused ingestion issues** [#32163](https://github.com/open-metadata/OpenMetadata/pull/32163): Ingestion now uses the official pydoris driver.
+- **Looker: trailing slash in hostPort broke SDK URL concatenation** [#31761](https://github.com/open-metadata/OpenMetadata/pull/31761): The trailing slash is stripped before the SDK builds request URLs.
+- **Ingestion pipeline deploys re-parsed the whole DAG folder every time** [#32101](https://github.com/open-metadata/OpenMetadata/pull/32101): Stops the full re-parse on every deploy and scales the deploy-pipelines deadline accordingly.
+
+### 📊 Data Quality
+
+- **Migration: tableDiff `supportedServices` migrated on upgrade** [#31715](https://github.com/open-metadata/OpenMetadata/pull/31715): Existing tableDiff test definitions carry their supported services forward automatically.
+- **BigQuery `uniqueCount` emitted invalid SQL for nested STRUCT subfield columns** [#31501](https://github.com/open-metadata/OpenMetadata/pull/31501): The metric now generates valid SQL for nested STRUCT subfields.
+- **Column values compared against `''` even when the column type couldn't hold it** [#31130](https://github.com/open-metadata/OpenMetadata/pull/31130): The empty-string comparison only runs when the column type supports it.
+- **Profiler data survived table hard deletes, and the orphan sweep deleted live column profiles** [#31556](https://github.com/open-metadata/OpenMetadata/pull/31556): Profiler data is now purged on hard delete, and the orphan sweep no longer touches live profiles.
+- **Time-series data was destroyed on every delete, not just hard deletes** [#31842](https://github.com/open-metadata/OpenMetadata/pull/31842): Time-series destruction is now bound specifically to hard delete.
+- **Dynamic Assertion control shown where it doesn't apply** [#31996](https://github.com/open-metadata/OpenMetadata/pull/31996): OpenMetadata now hides the control, since it's a Collate-only feature.
+- **No way to search within test suite details** [#32176](https://github.com/open-metadata/OpenMetadata/pull/32176): Adds search to the test suite details view.
+
+### 🔍 Search & Discovery
+
+- **Domain tree search failures rejected the request instead of surfacing the error** [#31823](https://github.com/open-metadata/OpenMetadata/pull/31823): Search failures in the domain tree are now surfaced instead of silently rejected.
+- **No way to filter Explore by Data Product** [#31940](https://github.com/open-metadata/OpenMetadata/pull/31940): Adds Data Product as a top-level Explore filter.
+- **Reindex jobs reported success even when the search cluster was degraded** [#32001](https://github.com/open-metadata/OpenMetadata/pull/32001): Reindex status now fails when the cluster is degraded.
+- **`columnDescriptionStatus` ignored nested columns** [#32203](https://github.com/open-metadata/OpenMetadata/pull/32203): The status now recurses into nested columns.
+- **Natural-language search bypassed RBAC and query filters** [#31727](https://github.com/open-metadata/OpenMetadata/pull/31727): Applies RBAC, `queryFilter`, and `deleted` to the NLQ happy path.
+- **Hybrid search defaulted keyword and semantic weighting incorrectly** [#32300](https://github.com/open-metadata/OpenMetadata/pull/32300): Swaps the default hybrid-search weighting for keyword vs. semantic.
+- **AI Governance Studio assets were not searchable via vector search** [#31738](https://github.com/open-metadata/OpenMetadata/pull/31738): AI Governance Studio assets are now vector-searchable.
+
+### 🛡️ Data Governance & Quality
+
+- **Glossary: system-defined relation types could be edited through the generic settings PUT** [#31944](https://github.com/open-metadata/OpenMetadata/pull/31944): Field edits to system-defined relation types are now rejected.
+- **ODCS (Open Data Contract Standard) passthrough was stripped by non-ODCS updates, and element attributes weren't round-tripped** [#31145](https://github.com/open-metadata/OpenMetadata/pull/31145): Preserves the ODCS passthrough on unrelated updates and round-trips element attributes correctly.
+- **Data Products couldn't be assigned across domains from the UI** [#32220](https://github.com/open-metadata/OpenMetadata/pull/32220): Assigning a Data Product across domains now works from the UI.
+- **Context Center pages ignored the requested entity status on creation** [#31728](https://github.com/open-metadata/OpenMetadata/pull/31728): The requested `entityStatus` now carries onto the created page.
+- **PII scanner missed separated Aadhaar numbers** [#31900](https://github.com/open-metadata/OpenMetadata/pull/31900): Recognizes Aadhaar numbers written with separators.
+- **PII scanner ties among equally weighted classifications were unresolved** [#31961](https://github.com/open-metadata/OpenMetadata/pull/31961): The NER (named entity recognition) scanner now breaks weighted-score ties by confidence.
+- **Incident Manager listing didn't enforce caller policies** [#32017](https://github.com/open-metadata/OpenMetadata/pull/32017): The listing now enforces the caller's policies.
+- **Masked secrets were overwritten during configuration updates** [#31989](https://github.com/open-metadata/OpenMetadata/pull/31989): Masked secrets are now preserved when a configuration is updated.
+- **User patch requests bypassed the expected permission checks** [#32323](https://github.com/open-metadata/OpenMetadata/pull/32323): Fixes user patch permission enforcement.
+- **Ingestion pipeline actions bypassed permission checks** [#32321](https://github.com/open-metadata/OpenMetadata/pull/32321): Ingestion pipeline actions now enforce the expected permissions.
+
+### 🔗 Lineage
+
+- **Lineage canvas scrolling broke when the filters panel was expanded** [#32036](https://github.com/open-metadata/OpenMetadata/pull/32036): Scrolling on the lineage canvas now works correctly with the filters panel open.
+- **Impact analysis table content was clipped instead of scrolling** [#32201](https://github.com/open-metadata/OpenMetadata/pull/32201): The lineage card now uses a flex layout with a scrollable content region.
+
+### 🤖 MCP Server / Automations
+
+- **MCP tool surface was expensive to call and unclear about what it returned** [#32019](https://github.com/open-metadata/OpenMetadata/pull/32019): Makes the MCP tool surface cheaper to call and more explicit about its return values.
+- **MCP error responses leaked a full Java stack trace on unauthenticated requests** [#31875](https://github.com/open-metadata/OpenMetadata/pull/31875): A 401 from an unauthenticated MCP call no longer serializes the underlying exception's stack trace.
+
+### ⚙️ Platform
+
+- **Migration: AutoPilotWorkflow BPMN (Business Process Model and Notation) redeploy and task supersede fallback for 2.0** [#32162](https://github.com/open-metadata/OpenMetadata/pull/32162): Adds the v2.0.1 migration that redeploys the AutoPilotWorkflow BPMN definition and adds a task supersede fallback.
+- **OIDC login handler and MCP callback auth relied on an EOL pac4j line** [#32380](https://github.com/open-metadata/OpenMetadata/pull/32380): Upgrades pac4j from 5.7.10 to 6.5.6 and adapts `AuthenticationCodeFlowHandler` and the MCP callback servlet to its API changes.
+- **Alerts offered event types a resource can't actually deliver** [#30587](https://github.com/open-metadata/OpenMetadata/pull/30587): Alerts now only offer the event types each resource can deliver.
+
+### 🎛️ UI
+
+- **A URL with no tab segment didn't render the tab already on screen** [#31448](https://github.com/open-metadata/OpenMetadata/pull/31448): The current tab renders correctly when the URL omits the tab segment.
+- **Selected persona reset to the default on page refresh** [#32201](https://github.com/open-metadata/OpenMetadata/pull/32201): The active persona now persists across a refresh via sessionStorage.
+- **Domain and Data Product rows were only partly clickable** [#31876](https://github.com/open-metadata/OpenMetadata/pull/31876): The whole row is now clickable.
+- **Persona customization pages crashed when a page was null** [#32034](https://github.com/open-metadata/OpenMetadata/pull/32034): Null persona customization pages are now handled gracefully.
+- **Explore filter typography regressed** [#32141](https://github.com/open-metadata/OpenMetadata/pull/32141): Restores the expected Explore filter typography.
+- **Modals and the right panel reopened immediately after being closed** [#32124](https://github.com/open-metadata/OpenMetadata/pull/32124): Closing a modal or right panel now stays closed.
+- **Sample Data tab crashed when a column was named `children`** [#31500](https://github.com/open-metadata/OpenMetadata/pull/31500): The Sample Data tab no longer crashes on a column literally named `children`.
+- **Dialog content clipped instead of scrolling when it overflowed** [#32224](https://github.com/open-metadata/OpenMetadata/pull/32224): Dialog content now scrolls instead of being clipped.
+- **`/my-data` redirect instead of rendering at `/`** [#32229](https://github.com/open-metadata/OpenMetadata/pull/32229): MyData renders at `/` directly instead of redirecting.
+- **Severity translations used hardcoded strings instead of generic i18n keys** [#32194](https://github.com/open-metadata/OpenMetadata/pull/32194): Severity labels now use generic translations.
+- **Icons and images rendered based on regex pre-validation instead of the real load outcome, with a cached-image race and misapplied icon classes** [#31982](https://github.com/open-metadata/OpenMetadata/pull/31982), [#32067](https://github.com/open-metadata/OpenMetadata/pull/32067), [#32110](https://github.com/open-metadata/OpenMetadata/pull/32110): Icon rendering now reflects the actual load outcome across tags, classification, and certification pages.
+- **Context Center "Dashboard" renamed to "Overview"** [#32125](https://github.com/open-metadata/OpenMetadata/pull/32125): Updates the surface name and route for consistency.
+- **AI-memory prompt used an inconsistent translation key** [#32140](https://github.com/open-metadata/OpenMetadata/pull/32140): Renames the key so the "what should AI remember" prompt translates correctly.
+- **ER diagram drawer wasn't full width, and the column panel could double-close** [#32337](https://github.com/open-metadata/OpenMetadata/pull/32337): The drawer now renders full width, and the column panel no longer double-closes.
+- **Login video gradient was hardcoded** [#32388](https://github.com/open-metadata/OpenMetadata/pull/32388): The login video gradient is now driven from `LoginClassBase`, so it can be customized.
+
+### 🔒 Security
+
+#### JVM / Backend
+
+- **`micrometer` → 1.16.7** for CVE-2026-59296 [#31927](https://github.com/open-metadata/OpenMetadata/pull/31927).
+- **Spring → 7.0.9** for CVE-2026-47886, CVE-2026-59282, and CVE-2026-59283 [#32222](https://github.com/open-metadata/OpenMetadata/pull/32222).
+- **`httpclient5` → 5.6.4** and **`jsoup` → 1.23.2** [#32293](https://github.com/open-metadata/OpenMetadata/pull/32293).
+- **Apache Jena and Fuseki → 6.2.0** for CVE-2026-61372 [#32274](https://github.com/open-metadata/OpenMetadata/pull/32274).
+- **Reactor moved to the 2026.0 train** to clear reactor-core/netty CVEs [#32393](https://github.com/open-metadata/OpenMetadata/pull/32393).
+
+#### UI
+
+- **`fast-uri` → 3.1.6** [#32139](https://github.com/open-metadata/OpenMetadata/pull/32139).
+
+#### Ingestion Images
+
+- **Airflow → 3.3.1** (CVE-2026-67587 / CVE-2026-54183) and **`expat` → 2.8.3** (CVE-2026-72522) [#31890](https://github.com/open-metadata/OpenMetadata/pull/31890).
+- **OpenSSL refreshed** [#32215](https://github.com/open-metadata/OpenMetadata/pull/32215).
+- **`pyathena` → 3.35.4** [#32167](https://github.com/open-metadata/OpenMetadata/pull/32167).
+- **`linux-libc-dev` upgraded** to clear kernel CVE scan findings [#32169](https://github.com/open-metadata/OpenMetadata/pull/32169).
+- **CVE-2026-68082 cleared** in the trixie images [#32259](https://github.com/open-metadata/OpenMetadata/pull/32259).

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "v2.0.1",
+    "date": "Released on 2nd September 2026",
+    "hasFeatures": false
+  },
+  {
     "version": "v2.0.0",
     "date": "Released on 24th August 2026.",
     "hasFeatures": true


### PR DESCRIPTION
## Summary
- Adds the product-updates page for v2.0.1 (`content/product-updates/v2.0.1.md`), curated from the 2.0.0...2.0.1 compare: connector fixes, data quality and governance correctness, search/lineage fixes, MCP hardening, and a security dependency cleanup grouped by JVM/UI/ingestion image.
- Adds the v2.0.1 entry to `content/product-updates/versions.json`.
- Every cited PR link was individually verified against `open-metadata/OpenMetadata` to confirm it exists and its title matches the described fix.

## Test plan
- [x] Ran the site locally (`npm run dev`) and confirmed `/product-updates` renders the v2.0.1 entry.
- [x] Verified no duplicate `id:` values across `content/product-updates/*.md`.
- [x] Ran the docs-collate `doc-review` skill against the new page and applied the applicable fixes.