### PR TITLE
feat: add release notes for OpenMetadata v1.13.5

### DIFF
--- a/content/product-updates/v1.13.5.md
+++ b/content/product-updates/v1.13.5.md
@@ -1,0 +1,86 @@
+---
+id: 124
+version: v1.13.5
+date: Released on 3rd September 2026
+---
+
+## Changelog
+
+OpenMetadata 1.13.5 is a maintenance release focused on connector reliability across REST, MLflow, DB2, Glue, and KafkaConnect, search and governance correctness, UI fixes, and a broad security dependency cleanup that also raises the ingestion package's Python floor to 3.10.
+
+### 🔌 Connectors & Ingestion
+
+- **Deploying an ingestion pipeline intermittently returned a 500 or timed out on Airflow 3.x** [#28744](https://github.com/open-metadata/OpenMetadata/pull/28744): Fixes a `DagContext` autoregister race in `build_dag` that caused the deploy endpoint to fail intermittently.
+- **REST/OpenAPI: array properties with an inline object schema emitted a synthetic `item: UNKNOWN` child** [#32007](https://github.com/open-metadata/OpenMetadata/pull/32007): Expands the item's properties with their OpenMetadata types and descriptions instead.
+- **REST/OpenAPI: API collections and endpoints could ingest out of order** [#31852](https://github.com/open-metadata/OpenMetadata/pull/31852): Persists all API collections before ingesting endpoints, so endpoints no longer reference a collection that hasn't been committed yet.
+- **Sorting the ingestion pipelines list by type returned a MySQL 500 error** [#31915](https://github.com/open-metadata/OpenMetadata/pull/31915): Adds server-side `displayName` sort and keyset pagination, resolving the error.
+- **MLflow Unity Catalog model version search broke on values needing escaping** [#31387](https://github.com/open-metadata/OpenMetadata/pull/31387): Switches to a single-quoted filter for the search query.
+- **MLflow 3.x model signatures were not extracted and the registry listing was unpaginated** [#32091](https://github.com/open-metadata/OpenMetadata/pull/32091): Extracts 3.x model signatures and paginates the registry listing.
+- **Athena: missing Lake Formation grants went undetected during test connection** [#29515](https://github.com/open-metadata/OpenMetadata/pull/29515): Test connection now detects missing Lake Formation grants.
+- **BigQuery: table last-modified time wasn't captured** [#30316](https://github.com/open-metadata/OpenMetadata/pull/30316): Ingests each table's last-modified timestamp into `lifeCycle.updated`, alongside the existing created timestamp.
+- **DB2: sqlalchemy-ibmi dialect incompatible with SQLAlchemy 2.0** [#30731](https://github.com/open-metadata/OpenMetadata/pull/30731): Adapts the dialect so DB2 ingestion works on SQLAlchemy 2.0.
+- **DB2: concurrent ingestion runs could conflict while installing the CLI driver** [#32154](https://github.com/open-metadata/OpenMetadata/pull/32154): Caches a successfully installed driver per process, serializes concurrent installs, and keeps failed installs retryable.
+- **Airflow: ingestion metadata was lost on API failures** [#31371](https://github.com/open-metadata/OpenMetadata/pull/31371): Prevents metadata loss when an Airflow API call fails mid-ingestion.
+- **Trino: unnamed and quoted ROW fields mishandled during reflection** [#31402](https://github.com/open-metadata/OpenMetadata/pull/31402): Reflection now correctly handles unnamed and quoted ROW fields.
+- **REST API: array-root schemas failed to parse** [#31698](https://github.com/open-metadata/OpenMetadata/pull/31698): Schemas with an array at the root now parse correctly.
+- **OpenLineage: Kafka SSL and password handling was missing on 1.13** [#32104](https://github.com/open-metadata/OpenMetadata/pull/32104): Backports SSL and password handling for Kafka-backed OpenLineage events.
+- **Doris: unofficial driver caused ingestion issues** [#32164](https://github.com/open-metadata/OpenMetadata/pull/32164): Ingestion now uses the official pydoris driver.
+- **Looker: trailing slash in hostPort broke SDK URL concatenation** [#31761](https://github.com/open-metadata/OpenMetadata/pull/31761): The trailing slash is stripped before the SDK builds request URLs.
+- **Glue: duplicate columns caused partition keys to drop the whole table** [#32106](https://github.com/open-metadata/OpenMetadata/pull/32106): Columns are deduplicated so partition keys no longer cause a full table drop.
+- **Glue: a custom databaseName dropped every schema** [#32400](https://github.com/open-metadata/OpenMetadata/pull/32400): Custom `databaseName` values no longer wipe out schema ingestion.
+- **Nested column metadata was lost during re-ingestion** [#32155](https://github.com/open-metadata/OpenMetadata/pull/32155): Nested column metadata now survives re-ingestion.
+- **KafkaConnect: topic-namespace membership was emitted as lineage** [#32420](https://github.com/open-metadata/OpenMetadata/pull/32420): Topic-namespace membership is no longer misreported as a lineage edge.
+- **`pygtrie` 2.6 broke `import airflow` on Python 3.10** [#32431](https://github.com/open-metadata/OpenMetadata/pull/32431): Caps `pygtrie` below 2.6 so ingestion imports Airflow correctly.
+
+### 📊 Data Quality
+
+- **`TestCaseRepository.linkedTablesCache` caused intermittent 500s** [#32119](https://github.com/open-metadata/OpenMetadata/pull/32119): Makes the cache static, stopping the intermittent errors.
+- **Databricks profiler: remaining SQL failures** [#32440](https://github.com/open-metadata/OpenMetadata/pull/32440): Resolves the remaining SQL failures in the Databricks profiler.
+- **Migration: TestSuite pipelines on PostgreSQL, or MySQL with a case-sensitive collation, kept the old flat profiler sampling fields** [#32511](https://github.com/open-metadata/OpenMetadata/pull/32511): Replays the 1.13.0 migration with the correct casing, so those pipelines get the nested `profileSampleConfig` like every other deployment.
+
+### 🔍 Search & Discovery
+
+- **No way to filter Explore by Data Product** [#32015](https://github.com/open-metadata/OpenMetadata/pull/32015): Adds Data Product as a top-level Explore filter.
+- **Search results could look stale right after a reindex reported complete** [#32171](https://github.com/open-metadata/OpenMetadata/pull/32171): A distributed reindex no longer reports success until the new index is fully promoted.
+- **`columnDescriptionStatus` ignored nested columns** [#32202](https://github.com/open-metadata/OpenMetadata/pull/32202): The status now recurses into nested columns.
+- **View lineage tore an FQN (fully qualified name) component in half if it contained a dot** [#31483](https://github.com/open-metadata/OpenMetadata/pull/31483): The FQN split is now quote-aware, so a schema or table name containing a `.` no longer breaks lineage resolution.
+
+### 🛡️ Data Governance & Quality
+
+- **A deleted domain's assets and activity reappeared if a domain of the same name was recreated** [#31879](https://github.com/open-metadata/OpenMetadata/pull/31879): Recreating a domain with a previously used name no longer resurfaces the old domain's assets and activity.
+- **Glossary: system-defined relation types could be edited through the generic settings PUT** [#31945](https://github.com/open-metadata/OpenMetadata/pull/31945): Field edits to system-defined relation types are now rejected.
+- **Incident Manager listing didn't enforce caller policies** [#31936](https://github.com/open-metadata/OpenMetadata/pull/31936): The listing now enforces the caller's policies.
+- **Data Products couldn't be assigned across domains even with domain validation disabled** [#32237](https://github.com/open-metadata/OpenMetadata/pull/32237): Cross-domain Data Product assignment now works when the domain validation rule is disabled.
+- **User patch requests bypassed the expected permission checks** [#32323](https://github.com/open-metadata/OpenMetadata/pull/32323): Fixes user patch permission enforcement.
+- **Pub/Sub credentials weren't masked correctly** [#32391](https://github.com/open-metadata/OpenMetadata/pull/32391): Converts persisted Pub/Sub credentials to their generated schema classes before masking and unmasking, so they're consistently protected.
+- **PII scanner missed separated Aadhaar numbers** [#31900](https://github.com/open-metadata/OpenMetadata/pull/31900): Recognizes Aadhaar numbers written with separators.
+- **PII scanner ties among equally weighted classifications were unresolved** [#31961](https://github.com/open-metadata/OpenMetadata/pull/31961): The NER (named entity recognition) scanner now breaks weighted-score ties by confidence.
+
+### 🔐 Authentication
+
+- **OIDC (OpenID Connect) login handler and MCP callback auth relied on an EOL pac4j line** [#32408](https://github.com/open-metadata/OpenMetadata/pull/32408): Upgrades pac4j and adapts the login and MCP callback handlers to its API changes.
+- **A Jetty version mismatch caused a runtime linkage error** [#32408](https://github.com/open-metadata/OpenMetadata/pull/32408): Aligns the Jetty dependency management to fix the mismatch.
+
+### 🎛️ UI
+
+- **Some views had no loading fallback while data streamed in** [#31827](https://github.com/open-metadata/OpenMetadata/pull/31827): Backports Suspense loader fallbacks to 1.13.
+- **A URL with no tab segment didn't render the tab already on screen** [#32029](https://github.com/open-metadata/OpenMetadata/pull/32029): The current tab renders correctly when the URL omits the tab segment.
+- **Persona customization pages crashed when a page was null** [#32037](https://github.com/open-metadata/OpenMetadata/pull/32037): Null persona customization pages are now handled gracefully.
+- **Icons occasionally failed to render** [#32066](https://github.com/open-metadata/OpenMetadata/pull/32066): Icon rendering now reflects the actual load outcome instead of a regex pre-check.
+- **Classification tags didn't display configured custom icons** [#32232](https://github.com/open-metadata/OpenMetadata/pull/32232): Custom icons configured for classification tags now display correctly.
+- **Selected persona reset to the default on page refresh** [#32268](https://github.com/open-metadata/OpenMetadata/pull/32268): The active persona now persists across a refresh via sessionStorage.
+- **Math equations were silently stripped on save** [#32402](https://github.com/open-metadata/OpenMetadata/pull/32402): Preserves `<block-math-equation>` nodes through both the frontend and backend sanitizers.
+
+### 🔒 Security
+
+- **`micrometer` → 1.16.7** for CVE-2026-59296 [#31926](https://github.com/open-metadata/OpenMetadata/pull/31926).
+- **`sqlparse` CVE remediated via collate-sqllineage 2.1.4 → 2.1.7, raising the ingestion package's Python floor from 3.9 to 3.10** [#31896](https://github.com/open-metadata/OpenMetadata/pull/31896).
+- **OpenSSL refreshed** in ingestion images [#32216](https://github.com/open-metadata/OpenMetadata/pull/32216).
+- **`pyathena` → 3.35.4** [#32166](https://github.com/open-metadata/OpenMetadata/pull/32166).
+- **Airflow → 3.3.1** (CVE-2026-67587 / CVE-2026-54183) and **`expat` → 2.8.3** (CVE-2026-72522) [#31890](https://github.com/open-metadata/OpenMetadata/pull/31890).
+- **Spring → 7.0.9** for CVE-2026-47886, CVE-2026-59282, and CVE-2026-59283 [#32408](https://github.com/open-metadata/OpenMetadata/pull/32408).
+- **Apache Jena and Fuseki → 6.2.0** for CVE-2026-61372 [#32408](https://github.com/open-metadata/OpenMetadata/pull/32408).
+- **`linux-libc-dev` upgraded** to clear kernel CVE scan findings in ingestion images [#32168](https://github.com/open-metadata/OpenMetadata/pull/32168).
+- **`httpclient5` → 5.6.4** and **`jsoup` → 1.23.2** [#32294](https://github.com/open-metadata/OpenMetadata/pull/32294).
+- **`fast-uri` → 3.1.6** [#32386](https://github.com/open-metadata/OpenMetadata/pull/32386).
+- **Reactor moved to the 2026.0 train** to clear reactor-core/netty CVEs [#32394](https://github.com/open-metadata/OpenMetadata/pull/32394).

--- a/content/product-updates/versions.json
+++ b/content/product-updates/versions.json
@@ -1,527 +1,532 @@
 [
   {
+    "version": "v1.13.5",
+    "date": "Released on 3rd September 2026",
+    "hasFeatures": false
+  },
+  {
     "version": "v2.0.1",
     "date": "Released on 2nd September 2026",
     "hasFeatures": false
   },
   {
     "version": "v2.0.0",
-    "date": "Released on 24th August 2026.",
+    "date": "Released on 24th August 2026",
     "hasFeatures": true
   },
   {
     "version": "v1.13.4",
-    "date": "Released on 21st August 2026.",
+    "date": "Released on 21st August 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.13.3",
-    "date": "Released on 31st July 2026.",
+    "date": "Released on 31st July 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.13.2",
-    "date": "Released on 30th July 2026.",
+    "date": "Released on 30th July 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.14",
-    "date": "Released on 28th July 2026.",
+    "date": "Released on 28th July 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.13",
-    "date": "Released on 6th July 2026.",
+    "date": "Released on 6th July 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.13.1",
-    "date": "Released on 27th June 2026.",
+    "date": "Released on 27th June 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.13.0",
-    "date": "Released on 8th June 2026.",
+    "date": "Released on 8th June 2026",
     "hasFeatures": true
   },
   {
     "version": "v1.12.12",
-    "date": "Released on 24th June 2026.",
+    "date": "Released on 24th June 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.11",
-    "date": "Released on 12th June 2026.",
+    "date": "Released on 12th June 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.10",
-    "date": "Released on 3rd June 2026.",
+    "date": "Released on 3rd June 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.9",
-    "date": "Released on 28th May 2026.",
+    "date": "Released on 28th May 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.8",
-    "date": "Released on 13th May 2026.",
+    "date": "Released on 13th May 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.7",
-    "date": "Released on 12th May 2026.",
+    "date": "Released on 12th May 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.6",
-    "date": "Released on 22nd April 2026.",
+    "date": "Released on 22nd April 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.5",
-    "date": "Released on 13th April 2026.",
+    "date": "Released on 13th April 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.4",
-    "date": "Released on 31st March 2026.",
+    "date": "Released on 31st March 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.3",
-    "date": "Released on 19th March 2026.",
+    "date": "Released on 19th March 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.11.12",
-    "date": "Released on 5th March 2026.",
+    "date": "Released on 5th March 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.12.1",
-    "date": "Released on 24th February 2026.",
+    "date": "Released on 24th February 2026",
     "hasFeatures": true
   },
   {
     "version": "v1.11.11",
-    "date": "Released on 25th February 2026.",
+    "date": "Released on 25th February 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.11.10",
-    "date": "Released on 18th February 2026.",
+    "date": "Released on 18th February 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.11.9",
-    "date": "Released on 16th February 2026.",
+    "date": "Released on 16th February 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.11.8",
-    "date": "Released on 4th February 2026.",
+    "date": "Released on 4th February 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.11.7",
-    "date": "Released on 28th January 2026.",
+    "date": "Released on 28th January 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.11.6",
-    "date": "Released on 21st January 2026.",
+    "date": "Released on 21st January 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.11.5",
-    "date": "Released on 14th January 2026.",
+    "date": "Released on 14th January 2026",
     "hasFeatures": false
   },
   {
     "version": "v1.11.4",
-    "date": "Released on 24th December 2025.",
+    "date": "Released on 24th December 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.9.16",
-    "date": "Released on 19th December 2025.",
+    "date": "Released on 19th December 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.11.3",
-    "date": "Released on 17th December 2025.",
+    "date": "Released on 17th December 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.11.2",
-    "date": "Released on 12th December 2025.",
+    "date": "Released on 12th December 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.11.1",
-    "date": "Released on 11th December 2025.",
+    "date": "Released on 11th December 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.11.0",
-    "date": "Released on 3rd December 2025.",
+    "date": "Released on 3rd December 2025",
     "hasFeatures": true
   },
   {
     "version": "v1.10.12",
-    "date": "Released on 3rd December 2025.",
+    "date": "Released on 3rd December 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.10.11",
-    "date": "Released on 2nd December 2025.",
+    "date": "Released on 2nd December 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.10.9",
-    "date": "Released on 27th November 2025.",
+    "date": "Released on 27th November 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.10.8",
-    "date": "Released on 21st November 2025.",
+    "date": "Released on 21st November 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.10.7",
-    "date": "Released on 18th November 2025.",
+    "date": "Released on 18th November 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.10.6",
-    "date": "Released on 18th November 2025.",
+    "date": "Released on 18th November 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.9.15",
-    "date": "Released on 11th November 2025.",
+    "date": "Released on 11th November 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.10.5",
-    "date": "Released on 10th November 2025.",
+    "date": "Released on 10th November 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.10.4",
-    "date": "Released on 31st October 2025.",
+    "date": "Released on 31st October 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.10.3",
-    "date": "Released on 22nd October 2025.",
+    "date": "Released on 22nd October 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.10.2",
-    "date": "Released on 20th October 2025.",
+    "date": "Released on 20th October 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.10.1",
-    "date": "Released on 10th October 2025.",
+    "date": "Released on 10th October 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.10.0",
-    "date": "Released on 8th October 2025.",
+    "date": "Released on 8th October 2025",
     "hasFeatures": true
   },
   {
     "version": "v1.9.12",
-    "date": "Released on 2nd October 2025.",
+    "date": "Released on 2nd October 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.9.10",
-    "date": "Released on 24th September 2025.",
+    "date": "Released on 24th September 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.9.9",
-    "date": "Released on 19th September 2025.",
+    "date": "Released on 19th September 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.9.8",
-    "date": "Released on 17th September 2025.",
+    "date": "Released on 17th September 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.9.7",
-    "date": "Released on 5th September 2025.",
+    "date": "Released on 5th September 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.9.5",
-    "date": "Released on 1st September 2025.",
+    "date": "Released on 1st September 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.9.4",
-    "date": "Released on 27th August 2025.",
+    "date": "Released on 27th August 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.9.2",
-    "date": "Released on 21st August 2025.",
+    "date": "Released on 21st August 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.9.0",
-    "date": "Released on 8th August 2025.",
+    "date": "Released on 8th August 2025",
     "hasFeatures": true
   },
   {
     "version": "v1.8.10",
-    "date": "Released on 5th August 2025.",
+    "date": "Released on 5th August 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.8.9",
-    "date": "Released on 1st August 2025.",
+    "date": "Released on 1st August 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.8.8",
-    "date": "Released on 30th July 2025.",
+    "date": "Released on 30th July 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.8.7",
-    "date": "Released on 24th July 2025.",
+    "date": "Released on 24th July 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.8.6",
-    "date": "Released on 18th July 2025.",
+    "date": "Released on 18th July 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.8.3",
-    "date": "Released on 10th July 2025.",
+    "date": "Released on 10th July 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.8.2",
-    "date": "Released on 9th July 2025.",
+    "date": "Released on 9th July 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.8.1",
-    "date": "Released on 30th June 2025.",
+    "date": "Released on 30th June 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.8.0",
-    "date": "Released on 22nd June 2025.",
+    "date": "Released on 22nd June 2025",
     "hasFeatures": true
   },
   {
     "version": "v1.7.5",
-    "date": "Released on 20th June 2025.",
+    "date": "Released on 20th June 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.7.4",
-    "date": "Released on 17th June 2025.",
+    "date": "Released on 17th June 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.7.3",
-    "date": "Released on 13th June 2025.",
+    "date": "Released on 13th June 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.7.2",
-    "date": "Released on 10th June 2025.",
+    "date": "Released on 10th June 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.7.1",
-    "date": "Released on 22nd May 2025.",
+    "date": "Released on 22nd May 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.7.0",
-    "date": "Released on 15th April 2025.",
+    "date": "Released on 15th April 2025",
     "hasFeatures": true
   },
   {
     "version": "v1.6.11",
-    "date": "Released on 28th April 2025.",
+    "date": "Released on 28th April 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.6.10",
-    "date": "Released on 23rd April 2025.",
+    "date": "Released on 23rd April 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.6.9",
-    "date": "Released on 17th April 2025.",
+    "date": "Released on 17th April 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.6.8",
-    "date": "Released on 8th April 2025.",
+    "date": "Released on 8th April 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.6.7",
-    "date": "Released on 28th March 2025.",
+    "date": "Released on 28th March 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.6.6",
-    "date": "Released on 14th March 2025.",
+    "date": "Released on 14th March 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.6.5",
-    "date": "Released on 27th February 2025.",
+    "date": "Released on 27th February 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.6.4",
-    "date": "Released on 19th February 2025.",
+    "date": "Released on 19th February 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.6.3",
-    "date": "Released on 29th January 2025.",
+    "date": "Released on 29th January 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.6.2",
-    "date": "Released on 10th January 2025.",
+    "date": "Released on 10th January 2025",
     "hasFeatures": false
   },
   {
     "version": "v1.6.1",
-    "date": "Released on 10th December 2024.",
+    "date": "Released on 10th December 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.6.0",
-    "date": "Released on 10th December 2024.",
+    "date": "Released on 10th December 2024",
     "hasFeatures": true
   },
   {
     "version": "v1.5.15",
-    "date": "Released on 16th December 2024.",
+    "date": "Released on 16th December 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.12",
-    "date": "Released on 25th November 2024.",
+    "date": "Released on 25th November 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.11",
-    "date": "Released on 15th November 2024.",
+    "date": "Released on 15th November 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.10",
-    "date": "Released on 31st October 2024.",
+    "date": "Released on 31st October 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.9",
-    "date": "Released on 29th October 2024.",
+    "date": "Released on 29th October 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.8",
-    "date": "Released on 24th October 2024.",
+    "date": "Released on 24th October 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.7",
-    "date": "Released on 17th October 2024.",
+    "date": "Released on 17th October 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.6",
-    "date": "Released on 3rd October 2024.",
+    "date": "Released on 3rd October 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.5",
-    "date": "Released on 23rd September 2024.",
+    "date": "Released on 23rd September 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.4",
-    "date": "Released on 12th September 2024.",
+    "date": "Released on 12th September 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.3",
-    "date": "Released on 10th September 2024.",
+    "date": "Released on 10th September 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.2",
-    "date": "Released on 2nd September 2024.",
+    "date": "Released on 2nd September 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.5.0",
-    "date": "Released on 26th August 2024.",
+    "date": "Released on 26th August 2024",
     "hasFeatures": true
   },
   {
     "version": "v1.4.8",
-    "date": "Released on 21st August 2024.",
+    "date": "Released on 21st August 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.4.7",
-    "date": "Released on 7th August 2024.",
+    "date": "Released on 7th August 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.4.6",
-    "date": "Released on 29th July 2024.",
+    "date": "Released on 29th July 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.4.5",
-    "date": "Released on 9th July 2024.",
+    "date": "Released on 9th July 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.4.4",
-    "date": "Released on 3rd July 2024.",
+    "date": "Released on 3rd July 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.4.3",
-    "date": "Released on 15th June 2024.",
+    "date": "Released on 15th June 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.4.2",
-    "date": "Released on 10th June 2024.",
+    "date": "Released on 10th June 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.4.1",
-    "date": "Released on 27th May 2024.",
+    "date": "Released on 27th May 2024",
     "hasFeatures": false
   },
   {
     "version": "v1.4.0",
-    "date": "Released on 21st May 2024.",
+    "date": "Released on 21st May 2024",
     "hasFeatures": true
   }
 ]

--- a/src/pages/product-updates.tsx
+++ b/src/pages/product-updates.tsx
@@ -501,18 +501,19 @@ export const getStaticProps: GetStaticProps = async () => {
   const versionsFile = path.join(contentDirectory, "versions.json");
   const versionsData = JSON.parse(fs.readFileSync(versionsFile, "utf8"));
 
-  // Sort versions in descending order (latest first)
-  const versions = [...versionsData].sort((a: any, b: any) => {
-    const versionA = a.version.replace("v", "").split(".").map(Number);
-    const versionB = b.version.replace("v", "").split(".").map(Number);
+  // Sort versions by release date, most recent first
+  const parseReleaseDate = (dateStr: string): number => {
+    const match = dateStr.match(
+      /(\d+)(?:st|nd|rd|th)\s+(\w+)\s+(\d{4})/
+    );
+    if (!match) return 0;
+    const [, day, month, year] = match;
+    return new Date(`${month} ${day}, ${year}`).getTime();
+  };
 
-    for (let i = 0; i < 3; i++) {
-      if (versionA[i] !== versionB[i]) {
-        return versionB[i] - versionA[i];
-      }
-    }
-    return 0;
-  });
+  const versions = [...versionsData].sort(
+    (a: any, b: any) => parseReleaseDate(b.date) - parseReleaseDate(a.date)
+  );
 
   // Read and process markdown files
   const versionData: { [key: string]: VersionData } = {};


### PR DESCRIPTION
## Summary
- Adds the product-updates page for v1.13.5 (`content/product-updates/v1.13.5.md`), curated from the 1.13.4...1.13 branch compare: connector fixes, a migration fix (TestSuite pipelines on PostgreSQL / case-sensitive MySQL collations kept the old flat profiler sampling fields), lineage/search correctness, governance fixes, and a security dependency cleanup that raises the ingestion package's Python floor to 3.10.
- Adds the v1.13.5 entry to `content/product-updates/versions.json` and strips the trailing period from every date string in that file for consistency.
- Fixes `src/pages/product-updates.tsx` to sort releases by parsed release date instead of semver — the old sort always put a higher version number first regardless of actual release date, which broke down once this 1.13.x patch released after 2.0.1.
- Every cited PR link was individually verified against `open-metadata/OpenMetadata`.

## Test plan
- [x] Ran the site locally and confirmed `/product-updates` renders v1.13.5 first in the sidebar (by date), followed by v2.0.1, matching actual release chronology.
- [x] Verified no duplicate `id:` values across `content/product-updates/*.md`.
- [x] Ran the docs-collate `doc-review` skill against the new page and applied the applicable fixes.